### PR TITLE
Remove parseZone from event functions

### DIFF
--- a/src/features/events/components/eventInfoCard.js
+++ b/src/features/events/components/eventInfoCard.js
@@ -87,21 +87,17 @@ const VSpace = styled.div`
 const dateFormat = 'D MMMM YYYY'
 
 const formatDayRange = (startTime, endTime) => {
-  if (startTime.parseZone().isSame('day', endTime)) {
-    return startTime.parseZone().format(dateFormat)
+  if (startTime.isSame('day', endTime)) {
+    return startTime.format(dateFormat)
   }
 
-  return `${startTime
-    .parseZone()
-    .format(dateFormat)} to ${endTime.parseZone().format(dateFormat)}`
+  return `${startTime.format(dateFormat)} to ${endTime.format(dateFormat)}`
 }
 
 const timeFormat = 'h:mma'
 
 const formatTimeRange = (startTime, endTime) =>
-  `${startTime.parseZone().format(timeFormat)} to ${endTime
-    .parseZone()
-    .format(timeFormat)}`
+  `${startTime.format(timeFormat)} to ${endTime.format(timeFormat)}`
 
 const formatPrice = (eventPriceLow, eventPriceHigh) => {
   if (eventPriceLow === 0 && eventPriceHigh === 0) {

--- a/src/features/events/helpers/index.js
+++ b/src/features/events/helpers/index.js
@@ -2,23 +2,23 @@ const moment = require('moment')
 const { dateFormat } = require('../../../constants')
 
 const formatTime = time => {
-  if (moment.parseZone(time).format('mm') === '00') {
-    return moment.parseZone(time).format('ha')
+  if (moment(time).format('mm') === '00') {
+    return moment(time).format('ha')
   }
-  return moment.parseZone(time).format('h:mma')
+  return moment(time).format('h:mma')
 }
 
 const formatDate = event => {
-  const year = moment.parseZone(event.startTime).year()
+  const year = moment(event.startTime).year()
 
-  const startDate = moment.parseZone(event.startTime).format('L')
-  const endDate = moment.parseZone(event.endTime).format('L')
+  const startDate = moment(event.startTime).format('L')
+  const endDate = moment(event.endTime).format('L')
 
-  const startMonth = moment.parseZone(event.startTime).format('MMM')
-  const endMonth = moment.parseZone(event.endTime).format('MMM')
+  const startMonth = moment(event.startTime).format('MMM')
+  const endMonth = moment(event.endTime).format('MMM')
 
-  const startDay = moment.parseZone(event.startTime).date()
-  const endDay = moment.parseZone(event.endTime).date()
+  const startDay = moment(event.startTime).date()
+  const endDay = moment(event.endTime).date()
 
   const startTime = formatTime(event.startTime)
   const endTime = formatTime(event.endTime)


### PR DESCRIPTION
remove parseZone to match fix done to the old PIL repo on Marcel's account that is used in Production currently.