### PR TITLE
Menu bar links & copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "format": "prettier --write 'src/**/*.js'",
     "lint": "eslint 'src/**/*.js'",
     "lint-fix": "eslint --fix 'src/**/*.js'",
-    "test": "jest --runInBand && codecov",
-    "test:watch": "jest --watch"
+    "test": "yarn jest --runInBand && codecov",
+    "test:watch": "yarn jest --watch"
   },
   "jest": {
     "moduleNameMapper": {

--- a/src/components/button/_spec.js
+++ b/src/components/button/_spec.js
@@ -25,7 +25,7 @@ describe('<Button/>', () => {
   })
 
   it('renders a gatsby link if the to prop is not http', () => {
-    const wrapper = mount(<Button to="/events/whats-on" />)
+    const wrapper = mount(<Button to="/events" />)
     expect(wrapper.find('GatsbyLink').exists()).toBeTruthy()
   })
 

--- a/src/components/navigation/nav/__snapshots__/_spec.js.snap
+++ b/src/components/navigation/nav/__snapshots__/_spec.js.snap
@@ -52,7 +52,7 @@ exports[`<Nav/> renders the component <Nav /> 1`] = `
                   "id": "nav-about",
                   "submenu": Array [
                     Object {
-                      "heading": "About us",
+                      "heading": "Pride",
                       "links": Array [
                         Object {
                           "title": "Our story",
@@ -62,9 +62,14 @@ exports[`<Nav/> renders the component <Nav /> 1`] = `
                           "title": "Our impact",
                           "url": "/about-us/impact",
                         },
+                      ],
+                    },
+                    Object {
+                      "heading": "Campaigns",
+                      "links": Array [
                         Object {
-                          "title": "Campaigns",
-                          "url": "/about-us/campaigns",
+                          "title": "Jubilee",
+                          "url": "/about-us/campaigns/jubilee",
                         },
                       ],
                     },
@@ -124,7 +129,7 @@ exports[`<Nav/> renders the component <Nav /> 1`] = `
                         },
                         Object {
                           "title": "What's on",
-                          "url": "/events/whats-on",
+                          "url": "/events",
                         },
                         Object {
                           "title": "Host an event",
@@ -144,7 +149,7 @@ exports[`<Nav/> renders the component <Nav /> 1`] = `
                           "url": "/events/prides-got-talent",
                         },
                         Object {
-                          "title": "Audition for Pride's Got Talent",
+                          "title": "Audition",
                           "url": "/events/prides-got-talent/audition",
                         },
                       ],

--- a/src/components/navigation/nav/__snapshots__/_spec.js.snap
+++ b/src/components/navigation/nav/__snapshots__/_spec.js.snap
@@ -182,6 +182,10 @@ exports[`<Nav/> renders the component <Nav /> 1`] = `
                           "title": "Buy merchandise",
                           "url": "/support-us/merchandise",
                         },
+                        Object {
+                          "title": "Work for Pride",
+                          "url": "/support-us/jobs",
+                        },
                       ],
                     },
                     Object {

--- a/src/components/navigation/nav/index.js
+++ b/src/components/navigation/nav/index.js
@@ -185,6 +185,10 @@ const Nav = () => {
                             title: 'Buy merchandise',
                             url: '/support-us/merchandise',
                           },
+                          {
+                            title: 'Work for Pride',
+                            url: '/support-us/jobs',
+                          },
                         ],
                       },
                       {

--- a/src/components/navigation/nav/index.js
+++ b/src/components/navigation/nav/index.js
@@ -64,11 +64,19 @@ const Nav = () => {
                     url: '/',
                     submenu: [
                       {
-                        heading: 'About us',
+                        heading: 'Pride',
                         links: [
                           { title: 'Our story', url: '/about-us' },
                           { title: 'Our impact', url: '/about-us/impact' },
-                          { title: 'Campaigns', url: '/about-us/campaigns' },
+                        ],
+                      },
+                      {
+                        heading: 'Campaigns',
+                        links: [
+                          {
+                            title: 'Jubilee',
+                            url: '/about-us/campaigns/jubilee',
+                          },
                         ],
                       },
                     ],
@@ -125,7 +133,7 @@ const Nav = () => {
                           },
                           {
                             title: "What's on",
-                            url: '/events/whats-on',
+                            url: '/events',
                           },
                           {
                             title: 'Host an event',
@@ -145,7 +153,7 @@ const Nav = () => {
                             url: '/events/prides-got-talent',
                           },
                           {
-                            title: "Audition for Pride's Got Talent",
+                            title: 'Audition',
                             url: '/events/prides-got-talent/audition',
                           },
                         ],

--- a/src/features/homepage/components/announcementHeader/__snapshots__/_spec.js.snap
+++ b/src/features/homepage/components/announcementHeader/__snapshots__/_spec.js.snap
@@ -6,7 +6,7 @@ exports[`AnnouncementHeader renders with default values 1`] = `
     Announcements
   </styles__Head>
   <styles__Title>
-    View events from across the LGBT+ community
+    Check out the latest updates from the Pride in London team.
   </styles__Title>
 </styles__Header>
 `;

--- a/src/features/homepage/components/announcementHeader/index.js
+++ b/src/features/homepage/components/announcementHeader/index.js
@@ -4,7 +4,7 @@ import { Head, Header, Title } from './styles'
 const AnnouncementHeader = () => (
   <Header>
     <Head>Announcements</Head>
-    <Title>View events from across the LGBT+ community</Title>
+    <Title>Check out the latest updates from the Pride in London team.</Title>
   </Header>
 )
 

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -22,9 +22,9 @@ const Blog = ({ data: { articles, views } }) => {
   return (
     <Fragment>
       <BannerImage
-        titleText="The Voice of Pride in London"
-        subtitleText="Find out what we're talking about in the Pride in London Community"
-        altText="The Voice of Pride in London"
+        titleText="News and views"
+        subtitleText="Read about what we’re talking about in the London LGBT+ community"
+        altText="News and views"
         imageSrc={background}
         imageFullWidth
         medium

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -4,25 +4,25 @@ import styled from 'styled-components'
 import moment from 'moment'
 import { graphql } from 'gatsby'
 import Helmet from 'react-helmet'
-import { noScroll } from '../../utilities'
-import { media } from '../../theme/media'
-import theme from '../../theme/theme'
-import { EventListingCard } from '../../features/events'
-import EventsFilters from '../../features/events/components/eventsFilters'
-import BannerImage from '../../components/banner/bannerImage'
-import Button from '../../components/button'
+import { noScroll } from '../utilities'
+import { media } from '../theme/media'
+import theme from '../theme/theme'
+import { EventListingCard } from '../features/events'
+import EventsFilters from '../features/events/components/eventsFilters'
+import BannerImage from '../components/banner/bannerImage'
+import Button from '../components/button'
 import {
   Container,
   Row,
   Column,
   StyledFlipMove,
   FlexColumn,
-} from '../../components/grid'
-import { Consumer } from '../../components/appContext'
-import { filterByLimit } from '../../features/events/helpers'
-import { dateFormat } from '../../constants'
-import filterIcon from '../../theme/assets/images/icon-filters.svg'
-import BannerImg from '../../theme/assets/images/banners/events/bg@2x.jpg'
+} from '../components/grid'
+import { Consumer } from '../components/appContext'
+import { filterByLimit } from '../features/events/helpers'
+import { dateFormat } from '../constants'
+import filterIcon from '../theme/assets/images/icon-filters.svg'
+import BannerImg from '../theme/assets/images/banners/events/bg@2x.jpg'
 
 const ColumnTextCenter = styled(Column)`
   text-align: center;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -182,7 +182,7 @@ const Home = () => (
                 <h2>Featured events</h2>
                 <p>View events from across the LGBT+ community.</p>
               </FeaturedEventsTitle>
-              <StyledButton wide={false} to="/events/whats-on">
+              <StyledButton wide={false} to="/events">
                 View all events
               </StyledButton>
             </FeaturedEventsHeader>

--- a/src/pages/support-us/partners.js
+++ b/src/pages/support-us/partners.js
@@ -109,8 +109,8 @@ const Sponsors = ({ data }) => {
   return (
     <Fragment>
       <BannerImage
-        titleText="Sponsor us"
-        subtitleText="Help us to keep Pride free for everyone by becoming one of our sponsors"
+        titleText="Partner with us"
+        subtitleText="Find out how your company can help us to keep Pride free for everyone"
         color={theme.colors.yellow}
         imageSrc={BannerImg}
       />
@@ -119,7 +119,7 @@ const Sponsors = ({ data }) => {
           <Row>
             <RelativeColumn width={1}>
               <CTABox>
-                <CTATitle>Sponsor us!</CTATitle>
+                <CTATitle>Find out more about becoming a Partner</CTATitle>
                 <CTABody>
                   Whether you're a big brand or a small business, and interested
                   in supporting Pride in London. We want to hear from you.


### PR DESCRIPTION
- Update ‘About us’ menu
- Update announcements copy
- Update Events URL from /events/whats-on to just /events
- Rename ‘Audition for Pride’s Got Talent’ to just ’Audition'
- Update copy on Partners page
- Add Jobs to menu
- Update blog copy