### PR TITLE
Fix bug onload for mobile

### DIFF
--- a/src/components/banner/bannerImage/index.js
+++ b/src/components/banner/bannerImage/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useLayoutEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'lodash.debounce'
 import { Column } from '../../grid'
@@ -32,7 +32,7 @@ const BannerImage = ({
   const [height, setHeight] = useState()
   const [width, setWidth] = useState()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const setDimensions = debounce(function() {
       setWidth(wrapper.current.offsetWidth)
       setHeight(wrapper.current.offsetHeight)

--- a/src/components/banner/bannerImage/styles.js
+++ b/src/components/banner/bannerImage/styles.js
@@ -110,12 +110,10 @@ export const ResponsiveImg = styled(Img)`
   width: 100% !important;
   transform: translate(-50%, -50%);
 
-  ${media.ie11`
-    img {
-      min-height: 100% !important;
-      width: 100% !important;
-    }
-  `};
+  img {
+    min-height: 100%;
+    min-width: 100%;
+  }
 `
 
 export const VideoWrapper = styled.div`


### PR DESCRIPTION
I noticed on mobile for a split second while the gatsby img is loading it would be a tiny thumbnail before becoming full size. This PR adds styles to fix this. 