### PR TITLE
Fixes issues in the event filtering mobile view

### DIFF
--- a/src/components/checkbox/index.js
+++ b/src/components/checkbox/index.js
@@ -32,6 +32,7 @@ const Input = styled.input`
     background-image: url(${checkmark});
     background-repeat: no-repeat;
     background-position: center center;
+    background-color: ${theme.colors.eucalyptusGreen};
 
     & + label {
       font-weight: 700;

--- a/src/features/events/components/eventsFilters.js
+++ b/src/features/events/components/eventsFilters.js
@@ -10,6 +10,7 @@ import iconClose from '../../../theme/assets/images/icon-close.svg'
 import EventDateFilter from '../filters/eventDateFilter'
 import EventFreeFilter from '../filters/eventFreeFilter'
 import EventDropdownFilter from '../filters/eventDropdownFilter'
+import Button from '../../../components/button'
 
 const FilterWrapper = styled(Flex)`
   background-color: ${theme.colors.white};
@@ -191,6 +192,19 @@ const CloseButton = styled.button`
     display: none;
   `};
 `
+
+const SubmitButtonContainer = styled.div`
+  margin: 20px 0 -20px 0;
+  width 100%;
+  padding: 20px;
+  box-shadow: 0 -3px 5px 0 rgba(0, 0, 0, 0.1);
+  height: 90px;
+
+  ${media.tablet`
+    display: none;
+  `};
+`
+
 class EventsFilters extends Component {
   state = {
     clickAnimation: false,
@@ -299,6 +313,16 @@ class EventsFilters extends Component {
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
               <EventFreeFilter />
             </FlexColumn>
+            <SubmitButtonContainer>
+              <Button
+                primary
+                fullmobile
+                onClick={this.props.toggleFiltersMobile}
+              >
+                Show {context.filteredEvents.length} event
+                {context.filteredEvents.length !== 1 && 's'}
+              </Button>
+            </SubmitButtonContainer>
           </FilterWrapper>
         )}
       </Consumer>

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -84,11 +84,12 @@ const Badge = styled.span`
   justify-content: center;
   margin-left: 10px;
   border-radius: 50%;
-  color: ${theme.colors.white};
+  color: ${theme.colors.indigo};
   background-color: ${theme.colors.eucalyptusGreen};
   height: 22px;
   width: 22px;
   line-height: 1;
+  font-size: 0.875rem;
 
   ${media.tablet`
     background-color: ${theme.colors.indigo};


### PR DESCRIPTION
Closes issue https://github.com/PrideInLondon/pride-london-web/issues/845.

Also addresses styling inconsistencies:

- badge font the wrong size (was `1rem`, now `0.875rem`)
- badge font the wrong colour (was `white`, now `indigo`)
- checkbox background wrong colour when checked (was `white`, now `eucalyptusGreen`)