### PR TITLE
WEBREF-21 ♻️ Refactor EventDropdownFilter component to use hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "styled-components": "^4.4.1",
     "styled-system": "^5.1.4",
     "tinycolor2": "^1.4.1",
+    "use-onclickoutside": "^0.3.1",
     "uuid-encoder": "^1.2.0"
   },
   "devDependencies": {

--- a/src/features/events/components/eventsFilters.js
+++ b/src/features/events/components/eventsFilters.js
@@ -263,8 +263,6 @@ class EventsFilters extends Component {
               <EventDropdownFilter
                 heading="Category"
                 filterName="eventCategories"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
                 sort="ASC"
               />
             </FlexColumn>
@@ -272,43 +270,27 @@ class EventsFilters extends Component {
               <EventDateFilter />
             </FlexColumn>
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
-              <EventDropdownFilter
-                heading="Area of London"
-                filterName="area"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
-              />
+              <EventDropdownFilter heading="Area of London" filterName="area" />
             </FlexColumn>
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
               <EventDropdownFilter
                 heading="Time of day"
                 filterName="timeOfDay"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
               />
             </FlexColumn>
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
-              <EventDropdownFilter
-                heading="Age group"
-                filterName="audience"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
-              />
+              <EventDropdownFilter heading="Age group" filterName="audience" />
             </FlexColumn>
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
               <EventDropdownFilter
                 heading="Venue options"
                 filterName="venueDetails"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
               />
             </FlexColumn>
             <FlexColumn width={[1, 1, 0.5, 0.3333]}>
               <EventDropdownFilter
                 heading="Accessibility"
                 filterName="accessibilityOptions"
-                filterOpen={context.state.filterOpen}
-                closeSiblingFilters={context.actions.closeSiblingFilters}
                 sort="ASC"
               />
             </FlexColumn>

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import onClickOutside from 'react-onclickoutside'
@@ -96,67 +96,55 @@ const Badge = styled.span`
   `};
 `
 
-class EventDropdownFilter extends Component {
-  state = {
-    isOpen: false,
+const EventDropdownFilter = ({
+  heading,
+  sort,
+  filterName,
+  filterOpen,
+  closeSiblingFilters,
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleMenu = () => setIsOpen(!isOpen)
+
+  EventDropdownFilter.handleClickOutside = () => {
+    if (filterName === filterOpen) setIsOpen(false)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return this.state.isOpen !== nextState.isOpen
-  }
+  useEffect(() => {
+    closeSiblingFilters(filterName, isOpen)
+  }, [closeSiblingFilters, filterName, isOpen])
 
-  handleClickOutside = () => {
-    if (this.props.filterName === this.props.filterOpen) {
-      this.setState({ isOpen: false }, () => {
-        this.props.closeSiblingFilters(this.props.filterName, this.state.isOpen)
-      })
-    }
-  }
-
-  toggleMenu = () => {
-    const isOpen = !this.state.isOpen
-    this.setState({ isOpen: isOpen }, () =>
-      this.props.closeSiblingFilters(this.props.filterName, isOpen)
-    )
-  }
-
-  render() {
-    return (
-      <Consumer>
-        {context => (
-          <Wrapper>
-            <FilterButton
-              aria-controls={this.props.filterName}
-              aria-expanded={this.state.isOpen}
-              type="button"
-              id={`button_${this.props.filterName}`}
-              onClick={this.toggleMenu}
-              isOpen={this.state.isOpen}
-              isActive={context.state.filters[this.props.filterName].length > 0}
-            >
-              {this.props.heading}
-              {context.state.filters[this.props.filterName].length > 0 ? (
-                <Badge>
-                  {context.state.filters[this.props.filterName].length}
-                </Badge>
-              ) : null}
-            </FilterButton>
-            <DropDown
-              isOpen={this.state.isOpen}
-              id={this.props.filterName}
-              aria-hidden={!this.state.isOpen}
-              aria-labelledby={`button_${this.props.filterName}`}
-            >
-              <CheckboxSet
-                filterName={this.props.filterName}
-                sort={this.props.sort}
-              />
-            </DropDown>
-          </Wrapper>
-        )}
-      </Consumer>
-    )
-  }
+  return (
+    <Consumer>
+      {context => (
+        <Wrapper>
+          <FilterButton
+            aria-controls={filterName}
+            aria-expanded={isOpen}
+            type="button"
+            id={`button_${filterName}`}
+            onClick={toggleMenu}
+            isOpen={isOpen}
+            isActive={context.state.filters[filterName].length > 0}
+          >
+            {heading}
+            {context.state.filters[filterName].length > 0 ? (
+              <Badge>{context.state.filters[filterName].length}</Badge>
+            ) : null}
+          </FilterButton>
+          <DropDown
+            isOpen={isOpen}
+            id={filterName}
+            aria-hidden={!isOpen}
+            aria-labelledby={`button_${filterName}`}
+          >
+            <CheckboxSet filterName={filterName} sort={sort} />
+          </DropDown>
+        </Wrapper>
+      )}
+    </Consumer>
+  )
 }
 
 EventDropdownFilter.propTypes = {
@@ -172,4 +160,8 @@ EventDropdownFilter.defaultProps = {
   sort: null,
 }
 
-export default onClickOutside(EventDropdownFilter)
+const clickOutsideConfig = {
+  handleClickOutside: () => EventDropdownFilter.handleClickOutside,
+}
+
+export default onClickOutside(EventDropdownFilter, clickOutsideConfig)

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useContext } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import useOnClickOutside from 'use-onclickoutside'
@@ -119,35 +119,32 @@ const EventDropdownFilter = ({
     isOpen,
   ])
 
+  const context = useContext(Consumer)
   return (
-    <Consumer>
-      {context => (
-        <Wrapper ref={ref}>
-          <FilterButton
-            aria-controls={filterName}
-            aria-expanded={isOpen}
-            type="button"
-            id={`button_${filterName}`}
-            onClick={toggleMenu}
-            isOpen={isOpen}
-            isActive={context.state.filters[filterName].length > 0}
-          >
-            {heading}
-            {context.state.filters[filterName].length > 0 ? (
-              <Badge>{context.state.filters[filterName].length}</Badge>
-            ) : null}
-          </FilterButton>
-          <DropDown
-            isOpen={isOpen}
-            id={filterName}
-            aria-hidden={!isOpen}
-            aria-labelledby={`button_${filterName}`}
-          >
-            <CheckboxSet filterName={filterName} sort={sort} />
-          </DropDown>
-        </Wrapper>
-      )}
-    </Consumer>
+    <Wrapper ref={ref}>
+      <FilterButton
+        aria-controls={filterName}
+        aria-expanded={isOpen}
+        type="button"
+        id={`button_${filterName}`}
+        onClick={toggleMenu}
+        isOpen={isOpen}
+        isActive={context.state.filters[filterName].length > 0}
+      >
+        {heading}
+        {context.state.filters[filterName].length > 0 ? (
+          <Badge>{context.state.filters[filterName].length}</Badge>
+        ) : null}
+      </FilterButton>
+      <DropDown
+        isOpen={isOpen}
+        id={filterName}
+        aria-hidden={!isOpen}
+        aria-labelledby={`button_${filterName}`}
+      >
+        <CheckboxSet filterName={filterName} sort={sort} />
+      </DropDown>
+    </Wrapper>
   )
 }
 

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -96,53 +96,57 @@ const Badge = styled.span`
   `};
 `
 
-const EventDropdownFilter = React.memo(
-  ({ heading, sort, filterName, filterOpen, closeSiblingFilters }) => {
-    const [isOpen, setIsOpen] = useState(false)
-    const context = useContext(AppContext)
+const EventDropdownFilter = ({
+  heading,
+  sort,
+  filterName,
+  filterOpen,
+  closeSiblingFilters,
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const { state } = useContext(AppContext)
 
-    const ref = useRef(null)
-    useOnClickOutside(ref, () => {
-      if (filterName === filterOpen) {
-        setIsOpen(!isOpen)
-      }
-    })
+  const ref = useRef(null)
+  useOnClickOutside(ref, () => {
+    if (filterName === filterOpen) {
+      setIsOpen(!isOpen)
+    }
+  })
 
-    const toggleMenu = () => setIsOpen(!isOpen)
-    useEffect(() => closeSiblingFilters(filterName, isOpen), [
-      closeSiblingFilters,
-      filterName,
-      isOpen,
-    ])
+  const toggleMenu = () => setIsOpen(!isOpen)
+  useEffect(() => closeSiblingFilters(filterName, isOpen), [
+    closeSiblingFilters,
+    filterName,
+    isOpen,
+  ])
 
-    return (
-      <Wrapper ref={ref}>
-        <FilterButton
-          aria-controls={filterName}
-          aria-expanded={isOpen}
-          type="button"
-          id={`button_${filterName}`}
-          onClick={toggleMenu}
-          isOpen={isOpen}
-          isActive={context.state.filters[filterName].length > 0}
-        >
-          {heading}
-          {context.state.filters[filterName].length > 0 ? (
-            <Badge>{context.state.filters[filterName].length}</Badge>
-          ) : null}
-        </FilterButton>
-        <DropDown
-          isOpen={isOpen}
-          id={filterName}
-          aria-hidden={!isOpen}
-          aria-labelledby={`button_${filterName}`}
-        >
-          <CheckboxSet filterName={filterName} sort={sort} />
-        </DropDown>
-      </Wrapper>
-    )
-  }
-)
+  return (
+    <Wrapper ref={ref}>
+      <FilterButton
+        aria-controls={filterName}
+        aria-expanded={isOpen}
+        type="button"
+        id={`button_${filterName}`}
+        onClick={toggleMenu}
+        isOpen={isOpen}
+        isActive={state.filters[filterName].length > 0}
+      >
+        {heading}
+        {state.filters[filterName].length > 0 ? (
+          <Badge>{state.filters[filterName].length}</Badge>
+        ) : null}
+      </FilterButton>
+      <DropDown
+        isOpen={isOpen}
+        id={filterName}
+        aria-hidden={!isOpen}
+        aria-labelledby={`button_${filterName}`}
+      >
+        <CheckboxSet filterName={filterName} sort={sort} />
+      </DropDown>
+    </Wrapper>
+  )
+}
 
 EventDropdownFilter.propTypes = {
   heading: PropTypes.string.isRequired,

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import onClickOutside from 'react-onclickoutside'
+import useOnClickOutside from 'use-onclickoutside'
 import { media } from '../../../theme/media'
 import theme from '../../../theme/theme'
 import { Consumer } from '../../../components/appContext'
@@ -105,20 +105,24 @@ const EventDropdownFilter = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false)
 
+  const ref = useRef(null)
+  useOnClickOutside(ref, () => {
+    if (filterName === filterOpen) {
+      setIsOpen(!isOpen)
+    }
+  })
+
   const toggleMenu = () => setIsOpen(!isOpen)
-
-  EventDropdownFilter.handleClickOutside = () => {
-    if (filterName === filterOpen) setIsOpen(false)
-  }
-
-  useEffect(() => {
-    closeSiblingFilters(filterName, isOpen)
-  }, [closeSiblingFilters, filterName, isOpen])
+  useEffect(() => closeSiblingFilters(filterName, isOpen), [
+    closeSiblingFilters,
+    filterName,
+    isOpen,
+  ])
 
   return (
     <Consumer>
       {context => (
-        <Wrapper>
+        <Wrapper ref={ref}>
           <FilterButton
             aria-controls={filterName}
             aria-expanded={isOpen}
@@ -160,8 +164,4 @@ EventDropdownFilter.defaultProps = {
   sort: null,
 }
 
-const clickOutsideConfig = {
-  handleClickOutside: () => EventDropdownFilter.handleClickOutside,
-}
-
-export default onClickOutside(EventDropdownFilter, clickOutsideConfig)
+export default EventDropdownFilter

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useContext } from 'react'
+import React, { useState, useRef, useContext } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import useOnClickOutside from 'use-onclickoutside'
@@ -96,29 +96,22 @@ const Badge = styled.span`
   `};
 `
 
-const EventDropdownFilter = ({
-  heading,
-  sort,
-  filterName,
-  filterOpen,
-  closeSiblingFilters,
-}) => {
+const EventDropdownFilter = ({ heading, sort, filterName }) => {
+  const { state, actions } = useContext(AppContext)
   const [isOpen, setIsOpen] = useState(false)
-  const { state } = useContext(AppContext)
 
   const ref = useRef(null)
   useOnClickOutside(ref, () => {
-    if (filterName === filterOpen) {
+    if (filterName === state.filterOpen) {
       setIsOpen(!isOpen)
+      actions.closeSiblingFilters(filterName, !isOpen)
     }
   })
 
-  const toggleMenu = () => setIsOpen(!isOpen)
-  useEffect(() => closeSiblingFilters(filterName, isOpen), [
-    closeSiblingFilters,
-    filterName,
-    isOpen,
-  ])
+  const toggleMenu = () => {
+    setIsOpen(!isOpen)
+    actions.closeSiblingFilters(filterName, !isOpen)
+  }
 
   return (
     <Wrapper ref={ref}>
@@ -151,8 +144,6 @@ const EventDropdownFilter = ({
 EventDropdownFilter.propTypes = {
   heading: PropTypes.string.isRequired,
   filterName: PropTypes.string.isRequired,
-  closeSiblingFilters: PropTypes.func.isRequired,
-  filterOpen: PropTypes.string,
   sort: PropTypes.oneOf(['ASC', 'DESC']),
 }
 
@@ -160,5 +151,4 @@ EventDropdownFilter.defaultProps = {
   filterOpen: null,
   sort: null,
 }
-
 export default EventDropdownFilter

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -96,57 +96,53 @@ const Badge = styled.span`
   `};
 `
 
-const EventDropdownFilter = ({
-  heading,
-  sort,
-  filterName,
-  filterOpen,
-  closeSiblingFilters,
-}) => {
-  const [isOpen, setIsOpen] = useState(false)
+const EventDropdownFilter = React.memo(
+  ({ heading, sort, filterName, filterOpen, closeSiblingFilters }) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const context = useContext(Consumer)
 
-  const ref = useRef(null)
-  useOnClickOutside(ref, () => {
-    if (filterName === filterOpen) {
-      setIsOpen(!isOpen)
-    }
-  })
+    const ref = useRef(null)
+    useOnClickOutside(ref, () => {
+      if (filterName === filterOpen) {
+        setIsOpen(!isOpen)
+      }
+    })
 
-  const toggleMenu = () => setIsOpen(!isOpen)
-  useEffect(() => closeSiblingFilters(filterName, isOpen), [
-    closeSiblingFilters,
-    filterName,
-    isOpen,
-  ])
+    const toggleMenu = () => setIsOpen(!isOpen)
+    useEffect(() => closeSiblingFilters(filterName, isOpen), [
+      closeSiblingFilters,
+      filterName,
+      isOpen,
+    ])
 
-  const context = useContext(Consumer)
-  return (
-    <Wrapper ref={ref}>
-      <FilterButton
-        aria-controls={filterName}
-        aria-expanded={isOpen}
-        type="button"
-        id={`button_${filterName}`}
-        onClick={toggleMenu}
-        isOpen={isOpen}
-        isActive={context.state.filters[filterName].length > 0}
-      >
-        {heading}
-        {context.state.filters[filterName].length > 0 ? (
-          <Badge>{context.state.filters[filterName].length}</Badge>
-        ) : null}
-      </FilterButton>
-      <DropDown
-        isOpen={isOpen}
-        id={filterName}
-        aria-hidden={!isOpen}
-        aria-labelledby={`button_${filterName}`}
-      >
-        <CheckboxSet filterName={filterName} sort={sort} />
-      </DropDown>
-    </Wrapper>
-  )
-}
+    return (
+      <Wrapper ref={ref}>
+        <FilterButton
+          aria-controls={filterName}
+          aria-expanded={isOpen}
+          type="button"
+          id={`button_${filterName}`}
+          onClick={toggleMenu}
+          isOpen={isOpen}
+          isActive={context.state.filters[filterName].length > 0}
+        >
+          {heading}
+          {context.state.filters[filterName].length > 0 ? (
+            <Badge>{context.state.filters[filterName].length}</Badge>
+          ) : null}
+        </FilterButton>
+        <DropDown
+          isOpen={isOpen}
+          id={filterName}
+          aria-hidden={!isOpen}
+          aria-labelledby={`button_${filterName}`}
+        >
+          <CheckboxSet filterName={filterName} sort={sort} />
+        </DropDown>
+      </Wrapper>
+    )
+  }
+)
 
 EventDropdownFilter.propTypes = {
   heading: PropTypes.string.isRequired,

--- a/src/features/events/filters/eventDropdownFilter.js
+++ b/src/features/events/filters/eventDropdownFilter.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import useOnClickOutside from 'use-onclickoutside'
 import { media } from '../../../theme/media'
 import theme from '../../../theme/theme'
-import { Consumer } from '../../../components/appContext'
+import { AppContext } from '../../../components/appContext'
 import CheckboxSet from '../../../components/checkboxSet'
 import iconDown from '../../../theme/assets/images/icon-chevron-down.svg'
 import iconUp from '../../../theme/assets/images/icon-chevron-up.svg'
@@ -99,7 +99,7 @@ const Badge = styled.span`
 const EventDropdownFilter = React.memo(
   ({ heading, sort, filterName, filterOpen, closeSiblingFilters }) => {
     const [isOpen, setIsOpen] = useState(false)
-    const context = useContext(Consumer)
+    const context = useContext(AppContext)
 
     const ref = useRef(null)
     useOnClickOutside(ref, () => {

--- a/src/features/help/components/dropDown.js
+++ b/src/features/help/components/dropDown.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import onClickOutside from 'react-onclickoutside'
+import onClickOutside from 'react-onclickoutside' // lib has bug in hooks implementation - see #PR 1289
 import theme from '../../../theme/theme'
 import { media } from '../../../theme/media'
 import chevronDown from '../../../theme/assets/images/icon-chevron-down-white.svg'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,6 +3608,11 @@ archive-type@^4.0.0:
   dependencies:
     file-type "^4.2.0"
 
+are-passive-events-supported@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/are-passive-events-supported/-/are-passive-events-supported-1.1.1.tgz#3db180a1753a2186a2de50a32cded3ac0979f5dc"
+  integrity sha512-5wnvlvB/dTbfrCvJ027Y4L4gW/6Mwoy1uFSavney0YO++GU+0e/flnjiBBwH+1kh7xNCgCOGvmJC3s32joYbww==
+
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -13032,7 +13037,14 @@ node-object-hash@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.0.0.tgz#9971fcdb7d254f05016bd9ccf508352bee11116b"
   integrity sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ==
 
-node-releases@^1.1.29, node-releases@^1.1.47:
+node-releases@^1.1.29:
+  version "1.1.47"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
+  integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
+  dependencies:
+    semver "^6.3.0"
+
+node-releases@^1.1.47:
   version "1.1.48"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.48.tgz#7f647f0c453a0495bcd64cbd4778c26035c2f03a"
   integrity sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==
@@ -18997,6 +19009,19 @@ use-callback-ref@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
   integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
+
+use-latest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.0.0.tgz#c86d2e4893b15f27def69da574a47136d107facb"
+  integrity sha512-CxmFi75KTXeTIBlZq3LhJ4Hz98pCaRKZHCpnbiaEHIr5QnuHvH8lKYoluPBt/ik7j/hFVPB8K3WqF6mQvLyQTg==
+
+use-onclickoutside@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/use-onclickoutside/-/use-onclickoutside-0.3.1.tgz#fdd723a6a499046b6bc761e4a03af432eee5917b"
+  integrity sha512-aahvbW5+G0XJfzj31FJeLsvc6qdKbzeTsQ8EtkHHq5qTg6bm/qkJeKLcgrpnYeHDDbd7uyhImLGdkbM9BRzOHQ==
+  dependencies:
+    are-passive-events-supported "^1.1.0"
+    use-latest "^1.0.0"
 
 use-sidecar@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### Implementation comments:

#### Replaced onClickOutside library
The react-onclickoutside library seems to have issues in the hook version
[https://github.com/Pomax/react-onclickoutside/issues/329 ](https://github.com/Pomax/react-onclickoutside/issues/329 )
It only attaches itself to the first instance (accessibilityOptions). 

Opted to use this alternative [https://github.com/Andarist/use-onclickoutside](https://github.com/Andarist/use-onclickoutside) 

This is also used here `/src/features/help/components/dropDown.js` which has yet to be refactored. 

#### Uncertainties

Replaced `shouldComponentUpdate` with `React.memo` but unsure if this was the right move or not.

#### Tests

No existing tests. Would prefer to add these with react-testing-library than enzyme?

 

 