### PR TITLE
WEBREF-17 ♻️ Refactor FilteredPagedCardContainer to handle content.category objects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|jpg|png|svg)$': '<rootDir>/empty-module.js',
   },
-  setupFiles: ['<rootDir>/config/jest.setup.js'],
+  setupFiles: ['<rootDir>/config/jest.setup.js', 'core-js'],
   setupFilesAfterEnv: ['<rootDir>/config/jest.setup.ts'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   coverageDirectory: './coverage/',

--- a/src/components/filteredPagedCardContainer/index.js
+++ b/src/components/filteredPagedCardContainer/index.js
@@ -49,22 +49,29 @@ export const calculateSelected = (
   }
 }
 
+// Card content with multiple categories will be array,
+// but content with single category eg. News Articles will be an object
+export const convertCardContentCategoryObjectsToArray = category =>
+  Array.isArray(category) ? category : [category.title]
+
 export const calculateShouldShowCard = (
   filterType,
   selected,
-  category,
+  category, // can be array or object
   showAllCategoryTitle
 ) => {
+  const categoryArr = convertCardContentCategoryObjectsToArray(category)
+
   switch (filterType) {
     case 'checkbox': {
       return selected.includes(showAllCategoryTitle)
         ? true
-        : category.some(cat => selected.includes(cat))
+        : categoryArr.some(cat => selected.includes(cat))
     }
     case 'radio':
       return selected === showAllCategoryTitle
         ? true
-        : category.includes(selected)
+        : categoryArr.includes(selected)
     default:
       return
   }
@@ -75,15 +82,15 @@ export const calculateAvailableCategories = (
   showAllCategoryTitle,
   cardContent
 ) => {
-  const cardCategories = cardContent.map(content => content.category)
-  const flattenedCardCategories = [].concat.apply([], cardCategories)
+  const cardCategories = cardContent.map(content =>
+    convertCardContentCategoryObjectsToArray(content.category)
+  )
+  const flattenedUniqueCardCategories = [...new Set(cardCategories.flat())]
 
   const availableCategories = categories.filter(
     category =>
       category.title === showAllCategoryTitle ||
-      flattenedCardCategories.some(
-        cardCategory => cardCategory === category.title
-      )
+      flattenedUniqueCardCategories.includes(category.title)
   )
 
   return availableCategories.length === 1 &&

--- a/src/components/filteredPagedCardContainer/index.test.js
+++ b/src/components/filteredPagedCardContainer/index.test.js
@@ -1,11 +1,29 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import FilteredPagedCardContainer, {
+  convertCardContentCategoryObjectsToArray,
   calculateInitialSelected,
   calculateSelected,
   calculateShouldShowCard,
   calculateAvailableCategories,
 } from './'
+
+describe('convertCardContentCategoryObjectsToArray', () => {
+  it.each`
+    categoryType | inputCategories        | expected
+    ${'array'}   | ${['Shop']}            | ${['Shop']}
+    ${'array'}   | ${['Sleep', 'Eat']}    | ${['Sleep', 'Eat']}
+    ${'object'}  | ${{ title: 'Events' }} | ${['Events']}
+  `(
+    'when category arg passed is $categoryType - eg. $inputCategories returns $expected',
+    ({ categoryType, inputCategories, expected }) => {
+      const categoryArray = convertCardContentCategoryObjectsToArray(
+        inputCategories
+      )
+      expect(categoryArray).toEqual(expected)
+    }
+  )
+})
 
 describe('calculateInitialSelected', () => {
   it.each`
@@ -58,13 +76,16 @@ describe('calculateSelected', () => {
 
 describe('calculateShouldShowCard', () => {
   it.each`
-    filterType    | selected          | category          | showAllCategoryTitle | expected
-    ${'checkbox'} | ${['foo', 'bar']} | ${['etc', 'foo']} | ${''}                | ${true}
-    ${'checkbox'} | ${['foo', 'bar']} | ${['baz', 'etc']} | ${''}                | ${false}
-    ${'checkbox'} | ${['all']}        | ${['baz']}        | ${'all'}             | ${true}
-    ${'radio'}    | ${'foo'}          | ${['foo', 'etc']} | ${''}                | ${true}
-    ${'radio'}    | ${'foo'}          | ${['bar', 'etc']} | ${''}                | ${false}
-    ${'radio'}    | ${'all'}          | ${['baz']}        | ${'all'}             | ${true}
+    filterType    | selected          | category            | showAllCategoryTitle | expected
+    ${'checkbox'} | ${['foo', 'bar']} | ${['etc', 'foo']}   | ${''}                | ${true}
+    ${'checkbox'} | ${['foo', 'bar']} | ${['baz', 'etc']}   | ${''}                | ${false}
+    ${'checkbox'} | ${['all']}        | ${['baz']}          | ${'all'}             | ${true}
+    ${'radio'}    | ${'foo'}          | ${['foo', 'etc']}   | ${''}                | ${true}
+    ${'radio'}    | ${'foo'}          | ${['bar', 'etc']}   | ${''}                | ${false}
+    ${'radio'}    | ${'all'}          | ${['baz']}          | ${'all'}             | ${true}
+    ${'radio'}    | ${'all'}          | ${{ title: 'baz' }} | ${'all'}             | ${true}
+    ${'radio'}    | ${'baz'}          | ${{ title: 'baz' }} | ${''}                | ${true}
+    ${'radio'}    | ${'foo'}          | ${{ title: 'baz' }} | ${''}                | ${false}
   `(
     'with $filterType filter type should return $expected if category is $category and already selected is $selected',
     ({ filterType, selected, category, showAllCategoryTitle, expected }) => {


### PR DESCRIPTION
Relates to #1266 and should be merged into that PR or master first.

FilteredPagedCardContainer is a component that loads NewsCard content along with a set of FilterButtons across the top. 

The original implementation rolled out for the Explore London page assumed all content passed in would have a 'category' field of type Array to handle multiple categories. 

Rolling this out in the newsContainer however, revealed that Article content is tagged with one category object, eg `category: {title: 'Events'}`  

### Implementation notes:

In order to reuse the FilteredPageCardContainer, we had to add a utilitty function that does what is says on the tin: `convertCardContentCategoryObjectsToArray`

Also refactored `calculateAvailableCategories` for readability.  In order to use `Array.prototype.flat()` in Jest, `core-js` needed to be added to the set up. [flat()](https://caniuse.com/#feat=array-flat) is not supported in all browsers yet but should not be an issue as we transpile to `es5`?  If a problem, can easily be replaced with `[].concat(...arr)`



