### PR TITLE
WEBREF-61 🐛 Strip invalid Win32 chars from event URL

### DIFF
--- a/src/features/events/helpers/index.js
+++ b/src/features/events/helpers/index.js
@@ -170,7 +170,10 @@ export function getDuration(start, end) {
 }
 
 export const generateEventSlug = ({ id, name, occurrence }) =>
-  `/event/${slugify(name, { lower: true })}${
+  `/event/${slugify(name, {
+    lower: true,
+    remove: /[<>:"/\\|?*,'+]/g,
+  })}${
     occurrence ? `-${moment(occurrence).format('DDMMYY')}` : ''
   }-${encoder.encode(id)}/`
 

--- a/src/features/events/helpers/index.test.js
+++ b/src/features/events/helpers/index.test.js
@@ -79,7 +79,7 @@ describe('generateEventSlug', () => {
     ${'cfaa55ae-9d84-4cac-bb3e-1bb84bd8ba0e'} | ${'foo'}       | ${null}                        | ${'/event/foo-6JrFngCyUZYHYY1Ay5ddWQ/'}
     ${'9c84548d-5a59-4c59-ad6f-3f1d898ba001'} | ${'foo-bar'}   | ${null}                        | ${'/event/foo-bar-4lLHF5FUWwwHcy0A07KGMT/'}
     ${'b2ff5bf6-20e5-491f-9706-8819f679ad7e'} | ${'foo - bar'} | ${null}                        | ${'/event/foo-bar-5RlKgiwNHXaWUkY7jck19y/'}
-    ${'a5a53094-22b6-4d38-b856-bd8fb6e005ff'} | ${'Foo: Bar'}  | ${null}                        | ${'/event/foo:-bar-52ZE0IY5o9ABOqlQ7DtdPT/'}
+    ${'a5a53094-22b6-4d38-b856-bd8fb6e005ff'} | ${'Foo: Bar'}  | ${null}                        | ${'/event/foo-bar-52ZE0IY5o9ABOqlQ7DtdPT/'}
     ${'6d267faa-bffc-4d6c-b9c7-ede073d66d5e'} | ${'foo-bar'}   | ${'2019-12-07T19:00:00+01:00'} | ${'/event/foo-bar-071219-3JxkyCOjnotcjZEY5eqLU6/'}
   `(
     'should generate a URL-friendly slug for event with id $id and name $name',

--- a/static/_redirects
+++ b/static/_redirects
@@ -146,3 +146,8 @@ https://events.prideinlondon.org/*     /events      301
 /line-up/world-area / 301
 /parade-groups /parade/groups
 /rainbow-planet /about-us/campaigns/jubilee/rainbow-planet 301
+/event/willma's-ballsdrop-bingo-130220-6mDXJCjswcrdp1BX93zI7X /event/willmas-ballsdrop-bingo-130220-6mDXJCjswcrdp1BX93zI7X 301
+/event/willma's-ballsdrop-bingo-090420-6mDXJCjswcrdp1BX93zI7X /event/willmas-ballsdrop-bingo-090420-6mDXJCjswcrdp1BX93zI7X 301
+/event/willma's-ballsdrop-bingo-180620-6mDXJCjswcrdp1BX93zI7X /event/willmas-ballsdrop-bingo-180620-6mDXJCjswcrdp1BX93zI7X 301
+/event/willma's-ballsdrop-bingo-240920-6mDXJCjswcrdp1BX93zI7X /event/willmas-ballsdrop-bingo-240920-6mDXJCjswcrdp1BX93zI7X 301
+/event/willma's-ballsdrop-bingo-291020-6mDXJCjswcrdp1BX93zI7X /event/willmas-ballsdrop-bingo-291020-6mDXJCjswcrdp1BX93zI7X 301


### PR DESCRIPTION
This issue arose with setting up local development on @SahelaR's Windows machine. Typically, we shouldn't have punctuation in the URLs anyway.