### PR TITLE
WEBNEW-85 🐛 Fixed a11y message for when no a11y info is passed to event page

### DIFF
--- a/src/events/__mocks__/index.js
+++ b/src/events/__mocks__/index.js
@@ -1,33 +1,3 @@
-export const mockEvents = [
-  {
-    data: {
-      locationName: 'Test',
-      eventPriceLow: 20,
-      phone: 'foo',
-      email: 'foo@foo.com',
-      ticketingUrl: 'https://foo.com',
-      accessibilityOptions: ['Test1', 'Test2'],
-      venueDetails: ['Indoors', 'Gender neutral toilets'],
-    },
-    pageContext: {
-      id: 'test-1',
-      startTime: '2006-06-02T13:30+00:00',
-      endTime: '2006-06-03T13:30+00:00',
-    },
-  },
-  {
-    data: {
-      locationName: 'Test 2 - Two days',
-      eventPriceLow: 10,
-    },
-    pageContext: {
-      id: 'test-2',
-      startTime: '2006-06-02T13:30+00:00',
-      endTime: '2006-06-02T13:30+00:00',
-    },
-  },
-]
-
 export const mockNodes = [
   //nodeOne
   {

--- a/src/events/event/EventInfoCard.js
+++ b/src/events/event/EventInfoCard.js
@@ -159,13 +159,18 @@ export default function EventInfoCard({
         title={locationName}
         detail={formatAddress(addressLine1, addressLine2, city, postcode)}
       />
-      {accessibilityOptions && accessibilityOptions.length > 0 && (
-        <Item
-          icon={<AccessibilityIcon />}
-          title="Accessibility"
-          detail={`${accessibilityOptions.join(', ')}.`}
-        />
-      )}
+      <Item
+        icon={<AccessibilityIcon />}
+        title="Accessibility"
+        detail={
+          !accessibilityOptions ||
+          accessibilityOptions.includes(
+            "My venue doesn't cater for any of these accessibility needs"
+          )
+            ? 'Accessibility is limited. Please contact venue for further info.'
+            : `${accessibilityOptions.join(', ')}.`
+        }
+      />
       {venueDetails &&
         venueDetails.indexOf(VENUE_DETAILS.genderNeutralToilets) > -1 && (
           <Item icon={<GenderIcon />} detail="Gender neutral toilets" />

--- a/src/events/event/EventInfoCard.test.js
+++ b/src/events/event/EventInfoCard.test.js
@@ -1,11 +1,31 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { mockEvents } from '../__mocks__'
 import EventInfoCard from './EventInfoCard'
 
 describe(EventInfoCard.name, () => {
-  it('renders correctly', () => {
-    const wrapper = mount(<EventInfoCard {...mockEvents[0]} />)
+  let props
+  beforeEach(() => {
+    props = {
+      data: {
+        eventPriceLow: 10,
+        locationName: 'ABC',
+        accessibilityOptions: null,
+      },
+      pageContext: {
+        id: '123',
+        startTime: '1970-01-01T09:00+00:00',
+        endTime: '1970-01-01T10:00+00:00',
+      },
+    }
+  })
+
+  it('renders recurring event date correctly', () => {
+    props.pageContext = {
+      ...props.pageContext,
+      startTime: '2006-06-02T13:30+00:00',
+      endTime: '2006-06-03T13:30+00:00',
+    }
+    const wrapper = mount(<EventInfoCard {...props} />)
     expect(
       wrapper
         .find('EventInfoCard__Title')
@@ -14,8 +34,13 @@ describe(EventInfoCard.name, () => {
     ).toBe('Friday 2 June 2006 to Saturday 3 June 2006')
   })
 
-  it('1 day event renders correctly', () => {
-    const wrapper = mount(<EventInfoCard {...mockEvents[1]} />)
+  it('renders single occurrence event date correctly', () => {
+    props.pageContext = {
+      ...props.pageContext,
+      startTime: '2006-06-02T13:30+00:00',
+      endTime: '2006-06-02T13:30+00:00',
+    }
+    const wrapper = mount(<EventInfoCard {...props} />)
     expect(
       wrapper
         .find('EventInfoCard__Title')
@@ -23,4 +48,23 @@ describe(EventInfoCard.name, () => {
         .text()
     ).toBe('Friday 2 June 2006')
   })
+
+  it.each`
+    accessibilityOptions                                               | expected
+    ${null}                                                            | ${'Accessibility is limited. Please contact venue for further info.'}
+    ${["My venue doesn't cater for any of these accessibility needs"]} | ${'Accessibility is limited. Please contact venue for further info.'}
+    ${['Foo', 'Bar', 'Baz']}                                           | ${'Foo, Bar, Baz.'}
+  `(
+    'shows a11y info as $expected for event with accessibility options $accessibilityOptions',
+    ({ accessibilityOptions, expected }) => {
+      props.data.accessibilityOptions = accessibilityOptions
+      const wrapper = mount(<EventInfoCard {...props} />)
+      expect(
+        wrapper
+          .find('EventInfoCard__Detail')
+          .at(1)
+          .text()
+      ).toBe(expected)
+    }
+  )
 })


### PR DESCRIPTION
Good events to test this with:

- [Event with a11y info](https://prideinlondon.org/event/hungama-47UiZ3NSeozRebBYUJz4rg)
- [Event without a11y info](https://prideinlondon.org/event/imaanfest-lgbtqi-muslim-pride-2AU6RYf063I3huBEPCb5Ba)