### PR TITLE
WEBNEW-97 🐛 Event times to always be displayed in London time

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "js-cookie": "^2.2.1",
     "lodash.debounce": "^4.0.8",
     "moment": "^2.23.0",
+    "moment-timezone": "^0.5.28",
     "polished": "^3.4.4",
     "querystring": "^0.2.0",
     "react": "^16.9.0",

--- a/src/events/EventCard.test.js
+++ b/src/events/EventCard.test.js
@@ -1,4 +1,8 @@
+import moment from 'moment'
+
 import { generateDisplayDate } from './EventCard'
+
+const formatToIsoDate = date => moment(date).format('YYYY-MM-DDTHH:mm+00:00')
 
 describe('generateDisplayDate', () => {
   let firstOfJanuary
@@ -17,7 +21,11 @@ describe('generateDisplayDate', () => {
     const end = new Date(firstOfJanuary)
     end.setHours(22, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
+    const actual = generateDisplayDate({
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
+      now: firstOfJanuary,
+    })
 
     expect(actual).toEqual('Today\u00A0\u00A0•\u00A0\u00A019:00 - 22:00')
   })
@@ -31,7 +39,11 @@ describe('generateDisplayDate', () => {
     end.setDate(firstOfJanuary.getDate() + 1) // set to January 02
     end.setHours(20, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
+    const actual = generateDisplayDate({
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
+      now: firstOfJanuary,
+    })
 
     expect(actual).toEqual('Tomorrow\u00A0\u00A0•\u00A0\u00A018:00 - 20:00')
   })
@@ -45,9 +57,31 @@ describe('generateDisplayDate', () => {
     end.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
     end.setHours(21, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
+    const actual = generateDisplayDate({
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
+      now: firstOfJanuary,
+    })
 
     expect(actual).toEqual('Fri, 01 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00')
+  })
+
+  it('should display the day and date it occurs when event occurs 2 or more days from now and during BST', () => {
+    const start = new Date(firstOfJanuary)
+    start.setMonth(firstOfJanuary.getMonth() + 5) // set to June 01
+    start.setHours(19, 30, 0)
+
+    const end = new Date(firstOfJanuary)
+    end.setMonth(firstOfJanuary.getMonth() + 5) // set to June 01
+    end.setHours(21, 0, 0)
+
+    const actual = generateDisplayDate({
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
+      now: firstOfJanuary,
+    })
+
+    expect(actual).toEqual('Sat, 01 Jun\u00A0\u00A0•\u00A0\u00A020:30 - 22:00')
   })
 
   it('should display a range of dates if end time is a different day from the start time', () => {
@@ -64,8 +98,8 @@ describe('generateDisplayDate', () => {
     lastOccurrence.setDate(firstOfJanuary.getDate() + 2) // set to February 03
 
     const actual = generateDisplayDate({
-      start,
-      end,
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
       lastOccurrence,
       now: firstOfJanuary,
     })
@@ -88,8 +122,8 @@ describe('generateDisplayDate', () => {
     lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
-      start,
-      end,
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
       lastOccurrence,
       now: firstOfJanuary,
     })
@@ -110,8 +144,8 @@ describe('generateDisplayDate', () => {
     lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
-      start,
-      end,
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
       lastOccurrence,
       now: firstOfJanuary,
     })
@@ -134,8 +168,8 @@ describe('generateDisplayDate', () => {
     lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
-      start,
-      end,
+      start: formatToIsoDate(start),
+      end: formatToIsoDate(end),
       lastOccurrence,
       now: firstOfJanuary,
     })

--- a/src/events/EventCard.test.js
+++ b/src/events/EventCard.test.js
@@ -1,147 +1,147 @@
 import { generateDisplayDate } from './EventCard'
 
 describe('generateDisplayDate', () => {
-  let firstOfJune
+  let firstOfJanuary
 
   beforeAll(() => {
-    // set up to be 1st of June 2019 @ 09:00
-    firstOfJune = new Date()
-    firstOfJune.setFullYear(2019, 5, 1)
-    firstOfJune.setHours(9, 0, 0)
+    // set up to be 1st of January 2019 @ 09:00 UTC
+    firstOfJanuary = new Date()
+    firstOfJanuary.setFullYear(2019, 0, 1)
+    firstOfJanuary.setHours(9, 0, 0)
   })
 
   it('should display the date as today when event occurs today', () => {
-    const start = new Date(firstOfJune)
+    const start = new Date(firstOfJanuary)
     start.setHours(19, 0, 0)
 
-    const end = new Date(firstOfJune)
+    const end = new Date(firstOfJanuary)
     end.setHours(22, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJune })
+    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
 
     expect(actual).toEqual('Today\u00A0\u00A0•\u00A0\u00A019:00 - 22:00')
   })
 
   it('should display the date as tomorrow when event occurs tomorrow', () => {
-    const start = new Date(firstOfJune)
-    start.setDate(firstOfJune.getDate() + 1)
+    const start = new Date(firstOfJanuary)
+    start.setDate(firstOfJanuary.getDate() + 1) // set to January 02
     start.setHours(18, 0, 0)
 
-    const end = new Date(firstOfJune)
-    end.setDate(firstOfJune.getDate() + 1)
+    const end = new Date(firstOfJanuary)
+    end.setDate(firstOfJanuary.getDate() + 1) // set to January 02
     end.setHours(20, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJune })
+    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
 
     expect(actual).toEqual('Tomorrow\u00A0\u00A0•\u00A0\u00A018:00 - 20:00')
   })
 
   it('should display the day and date it occurs when event occurs 2 or more days from now', () => {
-    const start = new Date(firstOfJune)
-    start.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const start = new Date(firstOfJanuary)
+    start.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
     start.setHours(19, 30, 0)
 
-    const end = new Date(firstOfJune)
-    end.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const end = new Date(firstOfJanuary)
+    end.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
     end.setHours(21, 0, 0)
 
-    const actual = generateDisplayDate({ start, end, now: firstOfJune })
+    const actual = generateDisplayDate({ start, end, now: firstOfJanuary })
 
-    expect(actual).toEqual('Mon, 01 Jul\u00A0\u00A0•\u00A0\u00A019:30 - 21:00')
+    expect(actual).toEqual('Fri, 01 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00')
   })
 
   it('should display a range of dates if end time is a different day from the start time', () => {
-    const start = new Date(firstOfJune)
-    start.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const start = new Date(firstOfJanuary)
+    start.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
     start.setHours(19, 30, 0)
 
-    const end = new Date(firstOfJune)
-    end.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const end = new Date(firstOfJanuary)
+    end.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
     end.setHours(21, 0, 0)
 
-    const lastOccurrence = new Date(firstOfJune)
-    lastOccurrence.setMonth(firstOfJune.getMonth() + 1)
-    lastOccurrence.setDate(firstOfJune.getDate() + 2) // set to July 03
+    const lastOccurrence = new Date(firstOfJanuary)
+    lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1)
+    lastOccurrence.setDate(firstOfJanuary.getDate() + 2) // set to February 03
 
     const actual = generateDisplayDate({
       start,
       end,
       lastOccurrence,
-      now: firstOfJune,
+      now: firstOfJanuary,
     })
 
     expect(actual).toEqual(
-      'Mon, 01 Jul - Wed, 03 Jul\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
+      'Fri, 01 Feb - Sun, 03 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
     )
   })
 
   it('should display a range of dates starting at today if end time is a different day from the start time and event series has already started', () => {
-    const start = new Date(firstOfJune)
-    start.setMonth(firstOfJune.getMonth() - 1) // set to May 01
+    const start = new Date(firstOfJanuary)
+    start.setMonth(firstOfJanuary.getMonth() - 1) // set to December 01
     start.setHours(19, 30, 0)
 
-    const end = new Date(firstOfJune)
-    end.setMonth(firstOfJune.getMonth() - 1) // set to May 01
+    const end = new Date(firstOfJanuary)
+    end.setMonth(firstOfJanuary.getMonth() - 1) // set to December 01
     end.setHours(21, 0, 0)
 
-    const lastOccurrence = new Date(firstOfJune)
-    lastOccurrence.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const lastOccurrence = new Date(firstOfJanuary)
+    lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
       start,
       end,
       lastOccurrence,
-      now: firstOfJune,
+      now: firstOfJanuary,
     })
 
     expect(actual).toEqual(
-      'Today - Mon, 01 Jul\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
+      'Today - Fri, 01 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
     )
   })
 
   it('should display a range of dates starting at today if end time is a different day from the start time and event series starts today', () => {
-    const start = new Date(firstOfJune) // set to June 01
+    const start = new Date(firstOfJanuary) // set to January 01
     start.setHours(19, 30, 0)
 
-    const end = new Date(firstOfJune) // set to June 01
+    const end = new Date(firstOfJanuary) // set to January 01
     end.setHours(21, 0, 0)
 
-    const lastOccurrence = new Date(firstOfJune)
-    lastOccurrence.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const lastOccurrence = new Date(firstOfJanuary)
+    lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
       start,
       end,
       lastOccurrence,
-      now: firstOfJune,
+      now: firstOfJanuary,
     })
 
     expect(actual).toEqual(
-      'Today - Mon, 01 Jul\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
+      'Today - Fri, 01 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
     )
   })
 
   it('should display a range of dates starting at today if end time is a different day from the start time and event series starts tomorrow', () => {
-    const start = new Date(firstOfJune)
-    start.setDate(firstOfJune.getDate() + 1) // set to June 02
+    const start = new Date(firstOfJanuary)
+    start.setDate(firstOfJanuary.getDate() + 1) // set to January 02
     start.setHours(19, 30, 0)
 
-    const end = new Date(firstOfJune)
-    end.setDate(firstOfJune.getDate() + 1) // set to June 02
+    const end = new Date(firstOfJanuary)
+    end.setDate(firstOfJanuary.getDate() + 1) // set to January 02
     end.setHours(21, 0, 0)
 
-    const lastOccurrence = new Date(firstOfJune)
-    lastOccurrence.setMonth(firstOfJune.getMonth() + 1) // set to July 01
+    const lastOccurrence = new Date(firstOfJanuary)
+    lastOccurrence.setMonth(firstOfJanuary.getMonth() + 1) // set to February 01
 
     const actual = generateDisplayDate({
       start,
       end,
       lastOccurrence,
-      now: firstOfJune,
+      now: firstOfJanuary,
     })
 
     expect(actual).toEqual(
-      'Tomorrow - Mon, 01 Jul\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
+      'Tomorrow - Fri, 01 Feb\u00A0\u00A0•\u00A0\u00A019:30 - 21:00'
     )
   })
 })

--- a/src/events/EventCard.ts
+++ b/src/events/EventCard.ts
@@ -1,5 +1,7 @@
 import moment from 'moment'
 
+import { formatTime } from './helpers'
+
 // second param required for testing
 const isToday = (date: Date, today: Date) => moment(today).isSame(date, 'day')
 
@@ -46,14 +48,14 @@ export const generateDisplayDate = ({
   lastOccurrence,
   now = new Date(), // note that this param should only be used for testing
 }: {
-  start: Date
-  end: Date
+  start: string // start time in format YYYY-MM-DDTHH:mm+HH:mm
+  end: string // end time in format YYYY-MM-DDTHH:mm+HH:mm
   lastOccurrence: Date
   now?: Date
 }) => {
   const prefix = lastOccurrence
-    ? generateMultiDatePrefix({ start, lastOccurrence, now })
-    : generateSingleDatePrefix({ start, now })
+    ? generateMultiDatePrefix({ start: new Date(start), lastOccurrence, now })
+    : generateSingleDatePrefix({ start: new Date(start), now })
 
   // Today • HH:mm - HH:mm (events occurring today)
   // Tomorrow • HH:mm - HH:mm (events occurring tomorrow)
@@ -62,7 +64,7 @@ export const generateDisplayDate = ({
   // Today - ddd, DD MMM  • HH:mm - HH:mm (recurring event series already started or starting today)
   // Tomorrow - ddd, DD MMM • HH:mm - HH:mm (recurring event series beginning tomorrow)
   // ddd, DD MMM - ddd, DD MMM • HH:mm - HH:mm (recurring event series beginning in 2 or more days)
-  return `${prefix}\u00A0\u00A0•\u00A0\u00A0${moment(start).format(
-    'HH:mm'
-  )} - ${moment(end).format('HH:mm')}`
+  return `${prefix}\u00A0\u00A0•\u00A0\u00A0${formatTime(start)} - ${formatTime(
+    end
+  )}`
 }

--- a/src/events/EventListingCard.js
+++ b/src/events/EventListingCard.js
@@ -82,12 +82,17 @@ const PaddedCalendarIcon = styled(CalendarIcon)`
   height: 1rem;
 `
 
+/**
+ * @param {object} props
+ * @param {string} props.startTime Start time in format YYYY-MM-DDTHH:mm+HH:mm
+ * @param {string} props.endTime End time in format YYYY-MM-DDTHH:mm+HH:mm
+ */
 const When = ({ startTime, endTime, recurrenceDates }) => (
   <CardDate>
     <PaddedCalendarIcon color={colors.darkCyan} />
     {generateDisplayDate({
-      start: new Date(startTime),
-      end: new Date(endTime),
+      start: startTime,
+      end: endTime,
       lastOccurrence:
         recurrenceDates &&
         new Date(

--- a/src/events/event/EventInfoCard.js
+++ b/src/events/event/EventInfoCard.js
@@ -16,7 +16,7 @@ import {
   TicketIcon,
 } from '../../components/icons'
 import { Button } from '../../components/button'
-import { formatPrice, isVirtualEvent } from '../helpers'
+import { formatPrice, formatTime, isVirtualEvent } from '../helpers'
 
 const Wrapper = styled.div`
   background-color: ${theme.colors.indigo};
@@ -96,9 +96,13 @@ export const formatDayRange = ({ startTime, endTime }) => {
     : `${startMoment.format(dateFormat)} to ${endMoment.format(dateFormat)}`
 }
 
+export const formatTimeWithoutZeroes = date =>
+  formatTime(date, 'h:mma').replace(':00', '')
+
 export const formatTimeRange = ({ startTime, endTime }) => {
-  const formatTime = time => moment(time).format('h:mma')
-  return `${formatTime(startTime)} to ${formatTime(endTime)}`
+  return `${formatTimeWithoutZeroes(startTime)} to ${formatTimeWithoutZeroes(
+    endTime
+  )}`
 }
 
 export const formatAddress = (addressLine1, addressLine2, city, postcode) =>

--- a/src/events/event/EventInfoCard.js
+++ b/src/events/event/EventInfoCard.js
@@ -16,7 +16,7 @@ import {
   TicketIcon,
 } from '../../components/icons'
 import { Button } from '../../components/button'
-import { formatPrice, formatTime, isVirtualEvent } from '../helpers'
+import { formatPrice, formatShortTime, isVirtualEvent } from '../helpers'
 
 const Wrapper = styled.div`
   background-color: ${theme.colors.indigo};
@@ -96,13 +96,8 @@ export const formatDayRange = ({ startTime, endTime }) => {
     : `${startMoment.format(dateFormat)} to ${endMoment.format(dateFormat)}`
 }
 
-export const formatTimeWithoutZeroes = date =>
-  formatTime(date, 'h:mma').replace(':00', '')
-
-export const formatTimeRange = ({ startTime, endTime }) => {
-  return `${formatTimeWithoutZeroes(startTime)} to ${formatTimeWithoutZeroes(
-    endTime
-  )}`
+export const formatTimeRange = (startTime, endTime) => {
+  return `${formatShortTime(startTime)} to ${formatShortTime(endTime)}`
 }
 
 export const formatAddress = (addressLine1, addressLine2, city, postcode) =>

--- a/src/events/event/EventInfoCard.js
+++ b/src/events/event/EventInfoCard.js
@@ -96,7 +96,7 @@ export const formatDayRange = ({ startTime, endTime }) => {
     : `${startMoment.format(dateFormat)} to ${endMoment.format(dateFormat)}`
 }
 
-export const formatTimeRange = (startTime, endTime) => {
+export const formatTimeRange = ({ startTime, endTime }) => {
   return `${formatShortTime(startTime)} to ${formatShortTime(endTime)}`
 }
 

--- a/src/events/event/EventInfoCard.test.js
+++ b/src/events/event/EventInfoCard.test.js
@@ -27,7 +27,7 @@ describe('formatTimeRange', () => {
     const startTime = '2020-03-04T09:00:00.000Z'
     const endTime = '2020-03-04T12:45:00.000Z'
     const actual = formatTimeRange({ startTime, endTime })
-    expect(actual).toEqual('9:00am to 12:45pm')
+    expect(actual).toEqual('9am to 12:45pm')
   })
 })
 
@@ -58,14 +58,4 @@ describe('Location', () => {
       expect(queryByText(expected)).toBeTruthy()
     }
   )
-})
-
-describe('formatTimeRange', () => {
-  it('should render time range', () => {
-    const startTime = '2020-01-01T20:00:00.000Z'
-    const endTime = '2020-01-01T23:30:00.000Z'
-    const expected = '8pm to 11:30pm'
-    const actual = formatTimeRange(startTime, endTime)
-    expect(actual).toEqual(expected)
-  })
 })

--- a/src/events/event/EventInfoCard.test.js
+++ b/src/events/event/EventInfoCard.test.js
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react'
 
 import {
   formatDayRange,
-  formatTimeWithoutZeroes,
   formatTimeRange,
   formatAddress,
   Location,
@@ -61,18 +60,12 @@ describe('Location', () => {
   )
 })
 
-describe('formatTimeWithoutZeroes', () => {
-  it.each`
-    date                          | expected
-    ${'2020-01-01T09:30:00.000Z'} | ${'9:30am'}
-    ${'2020-01-01T09:00:00.000Z'} | ${'9am'}
-    ${'2020-01-01T20:45:00.000Z'} | ${'8:45pm'}
-    ${'2020-01-01T20:00:00.000Z'} | ${'8pm'}
-  `(
-    'should render time as $expected when date is $date',
-    ({ date, expected }) => {
-      const actual = formatTimeWithoutZeroes(date)
-      expect(actual).toEqual(expected)
-    }
-  )
+describe('formatTimeRange', () => {
+  it('should render time range', () => {
+    const startTime = '2020-01-01T20:00:00.000Z'
+    const endTime = '2020-01-01T23:30:00.000Z'
+    const expected = '8pm to 11:30pm'
+    const actual = formatTimeRange(startTime, endTime)
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/events/event/EventInfoCard.test.js
+++ b/src/events/event/EventInfoCard.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 
 import {
   formatDayRange,
+  formatTimeWithoutZeroes,
   formatTimeRange,
   formatAddress,
   Location,
@@ -56,6 +57,22 @@ describe('Location', () => {
     ({ platform, props, expected }) => {
       const { queryByText } = render(<Location {...{ platform, ...props }} />)
       expect(queryByText(expected)).toBeTruthy()
+    }
+  )
+})
+
+describe('formatTimeWithoutZeroes', () => {
+  it.each`
+    date                          | expected
+    ${'2020-01-01T09:30:00.000Z'} | ${'9:30am'}
+    ${'2020-01-01T09:00:00.000Z'} | ${'9am'}
+    ${'2020-01-01T20:45:00.000Z'} | ${'8:45pm'}
+    ${'2020-01-01T20:00:00.000Z'} | ${'8pm'}
+  `(
+    'should render time as $expected when date is $date',
+    ({ date, expected }) => {
+      const actual = formatTimeWithoutZeroes(date)
+      expect(actual).toEqual(expected)
     }
   )
 })

--- a/src/events/event/EventShareSection.js
+++ b/src/events/event/EventShareSection.js
@@ -8,7 +8,7 @@ import FacebookIcon from '../../components/icons/facebook'
 import LinkedinIcon from '../../components/icons/linkedin'
 import { media } from '../../theme/media'
 import theme from '../../theme/theme'
-import { formatTime } from '../helpers'
+import { formatShortTime } from '../helpers'
 
 const ShareList = styled.div`
   display: inline-flex;
@@ -60,7 +60,7 @@ const ShareLink = styled.a`
 
 const shareText = (name, date, location) => {
   const startDay = moment(date).format('ddd D MMM')
-  const startTime = formatTime(date)
+  const startTime = formatShortTime(date)
   return `I'm heading to ${name} on ${startDay} at ${startTime}. Join me!\n\nFind out more here:\n${location}`
 }
 

--- a/src/events/helpers.js
+++ b/src/events/helpers.js
@@ -20,6 +20,9 @@ export const formatTime = (isoDate, format = 'HH:mm') =>
     .tz('Europe/London')
     .format(format)
 
+export const formatShortTime = date =>
+  formatTime(date, 'h:mma').replace(':00', '')
+
 export function filterPastEvents(event) {
   const today = moment()
   return event.node && event.node.endTime

--- a/src/events/helpers.js
+++ b/src/events/helpers.js
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import momentTz from 'moment-timezone'
 import slugify from 'slugify'
 import UuidEncoder from 'uuid-encoder'
 import constants from '../constants'
@@ -10,11 +11,13 @@ export const formatPrice = (eventPriceLow, eventPriceHigh) =>
     ? 'Free'
     : `From £${eventPriceLow.toFixed(2).replace('.00', '')}`
 
-export const formatTime = time => {
-  return moment(time).format('mm') === '00'
-    ? moment(time).format('ha')
-    : moment(time).format('h:mma')
-}
+/**
+ * @param {string} isoDate Date in format YYYY-MM-DDTHH:mm+HH:mm
+ */
+export const formatTime = isoDate =>
+  momentTz(isoDate)
+    .tz('Europe/London')
+    .format('HH:mm')
 
 export function filterPastEvents(event) {
   const today = moment()

--- a/src/events/helpers.js
+++ b/src/events/helpers.js
@@ -13,11 +13,12 @@ export const formatPrice = (eventPriceLow, eventPriceHigh) =>
 
 /**
  * @param {string} isoDate Date in format YYYY-MM-DDTHH:mm+HH:mm
+ * @param {string} [format] Optional time format, default is HH:mm
  */
-export const formatTime = isoDate =>
+export const formatTime = (isoDate, format = 'HH:mm') =>
   momentTz(isoDate)
     .tz('Europe/London')
-    .format('HH:mm')
+    .format(format)
 
 export function filterPastEvents(event) {
   const today = moment()

--- a/src/events/helpers.test.js
+++ b/src/events/helpers.test.js
@@ -1,5 +1,6 @@
 import {
   formatTime,
+  formatShortTime,
   filterPastEvents,
   getDuration,
   sanitizeDates,
@@ -51,6 +52,22 @@ describe('formatTime', () => {
     'should format time $date with requested override format when supplied',
     ({ date, expected }) => {
       const actual = formatTime(date, 'h:mma')
+      expect(actual).toEqual(expected)
+    }
+  )
+})
+
+describe('formatShortTime', () => {
+  it.each`
+    date                          | expected
+    ${'2020-01-01T09:30:00.000Z'} | ${'9:30am'}
+    ${'2020-01-01T09:00:00.000Z'} | ${'9am'}
+    ${'2020-01-01T20:45:00.000Z'} | ${'8:45pm'}
+    ${'2020-01-01T20:00:00.000Z'} | ${'8pm'}
+  `(
+    'should render time as $expected when date is $date',
+    ({ date, expected }) => {
+      const actual = formatShortTime(date)
       expect(actual).toEqual(expected)
     }
   )

--- a/src/events/helpers.test.js
+++ b/src/events/helpers.test.js
@@ -1,4 +1,5 @@
 import {
+  formatTime,
   filterPastEvents,
   getDuration,
   sanitizeDates,
@@ -26,6 +27,21 @@ const pastEvent = {
     endTime: yesterday,
   },
 }
+
+describe('formatTime', () => {
+  it.each`
+    date                        | expected
+    ${'2020-01-01T09:30+00:00'} | ${'09:30' /* 1st January 2020 09:30 UTC */}
+    ${'2020-06-01T09:30+00:00'} | ${'10:30' /* 1st June 2020 09:30 UTC */}
+    ${'2020-06-01T09:30+01:00'} | ${'09:30' /* 1st June 2020 09:30 BST */}
+  `(
+    'should format time $date as $expected according to current London timezone',
+    ({ date, expected }) => {
+      const actual = formatTime(date)
+      expect(actual).toEqual(expected)
+    }
+  )
+})
 
 describe('filterPastEvents', () => {
   it('returns true if date is after today', () => {

--- a/src/events/helpers.test.js
+++ b/src/events/helpers.test.js
@@ -34,10 +34,23 @@ describe('formatTime', () => {
     ${'2020-01-01T09:30+00:00'} | ${'09:30' /* 1st January 2020 09:30 UTC */}
     ${'2020-06-01T09:30+00:00'} | ${'10:30' /* 1st June 2020 09:30 UTC */}
     ${'2020-06-01T09:30+01:00'} | ${'09:30' /* 1st June 2020 09:30 BST */}
+    ${'2020-06-01T09:30+01:00'} | ${'09:30' /* 1st June 2020 09:30 BST */}
   `(
     'should format time $date as $expected according to current London timezone',
     ({ date, expected }) => {
       const actual = formatTime(date)
+      expect(actual).toEqual(expected)
+    }
+  )
+
+  it.each`
+    date                        | expected
+    ${'2020-01-01T09:30+00:00'} | ${'9:30am'}
+    ${'2020-01-01T19:30+00:00'} | ${'7:30pm'}
+  `(
+    'should format time $date with requested override format when supplied',
+    ({ date, expected }) => {
+      const actual = formatTime(date, 'h:mma')
       expect(actual).toEqual(expected)
     }
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -13237,7 +13237,14 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@>=1.6.0, moment@>=2.17.1, moment@^2.23.0, moment@^2.24.0:
+moment-timezone@^0.5.28:
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
+  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@>=1.6.0, moment@>=2.17.1, moment@^2.23.0, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
This also requires event entries in Contentful to be updated with the correct offset in order for the code to fully work.