### PR TITLE
WEBNEW-177 ✨ Implement age verification modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^25.1.0",
     "@types/jest-axe": "^3.2.1",
+    "@types/js-cookie": "^2.2.6",
     "@types/moment-timezone": "^0.5.13",
     "@types/react": "^16.9.19",
     "@types/react-dates": "^17.1.7",

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -33,25 +33,31 @@ export const Modal = ({
   const firstUpdate = useRef(true)
 
   useLayoutEffect(() => {
-    isOpen && noScroll.on()
+    setTimeout(() => {
+      isOpen && noScroll.on()
+    })
     const undo = ref && ref.current && hideOthers(ref.current)
+    const cleanup = () => {
+      noScroll.off()
+      undo && undo()
+    }
 
     // Prevent onOpen or onClose callbacks executing on initial render
     if (firstUpdate.current) {
       firstUpdate.current = false
       return
     }
-
+    if (!isOpen) {
+      cleanup()
+    }
     if (isOpen && onOpen) {
       onOpen()
     }
     if (!isOpen && onClose) {
       onClose()
     }
-
     return () => {
-      noScroll.off()
-      undo && undo()
+      cleanup()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])

--- a/src/fifty-two/FiftyTwoPage.tsx
+++ b/src/fifty-two/FiftyTwoPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import Cookies from 'js-cookie'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import { Banner } from '../components/banner'
 import { PageIntro } from '../components/pageIntro'
@@ -8,6 +9,9 @@ import { Category } from '../components/categoryFilter/CategoryFilter.types'
 import { Gallery, GalleryContainer } from '../components/gallery'
 import { Button } from '../components/button'
 import { GalleryCard } from '../components/galleryCard'
+import { CTALink } from '../components/ctaLink'
+import { Modal } from '../components/modal/Modal'
+import { Wrapper } from '../components/wrapper/Wrapper'
 import { colors } from '../theme/colors'
 import { shuffle } from '../utils/iteration-utils'
 import { generateFiftyTwoEntrySlug } from './helpers'
@@ -141,6 +145,44 @@ export const FiftyTwoPage: React.FC<FiftyTwoPageProps> = ({
           )
         }}
       />
+      <Modal
+        trigger={<Button>Click to open</Button>}
+        dismissable={false}
+        open={Cookies.get('fiftyTwo') === 'accept' ? false : true}
+        onClose={() => {
+          Cookies.set('fiftyTwo', 'accept', { expires: 365 })
+        }}
+      >
+        {({ setIsOpen }) => (
+          <Wrapper textAlign="center" width="100%">
+            <H3 color="white">Age verification</H3>
+            <P color="white" variant="lg">
+              The following page contains artwork depicting themes and content
+              that may not be suitable for under 18s.
+            </P>
+            <Button
+              mr="lg"
+              onClick={() => {
+                setIsOpen(false)
+              }}
+            >
+              Continue to page
+            </Button>
+            <Button variant="outline-white" to="/">
+              Redirect me
+            </Button>
+            <P variant="sm" color="white" mt="lg">
+              See Fifty-Two's{' '}
+              <CTALink
+                to="https://prideinlondon.org/fifty-two/terms/"
+                color="white"
+              >
+                terms and conditions
+              </CTALink>
+            </P>
+          </Wrapper>
+        )}
+      </Modal>
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"


### PR DESCRIPTION
Reopening https://github.com/PrideInLondon/pride-london-web/pull/1615 following branch corruption.

Fix modal bugs, implement fifty-two cookie

(cherry picked from commit ba79a2334ad50e4c5646bc9f85b9378127cd96c6)
