### PR TITLE
WEBNEW-198 🐛 Exclude fallback colours from tag font

### DIFF
--- a/src/components/tag/Tag.styles.ts
+++ b/src/components/tag/Tag.styles.ts
@@ -8,7 +8,6 @@ import { TagProps } from './Tag.types'
 const getMostReadable = (color: string) =>
   tinycolor
     .mostReadable(color, [colors.white, colors.indigo], {
-      includeFallbackColors: true,
       level: 'AAA',
       size: 'small',
     })


### PR DESCRIPTION
This was falling back to black instead of indigo.
