### PR TITLE
WEBNEW-203 📌 Explicitly pin gatsby-link to 2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.24.8",
     "gatsby-image": "^2.4.13",
-    "gatsby-link": "^2.4.13",
+    "gatsby-link": "2.4.3",
     "gatsby-plugin-layout": "^1.3.10",
     "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10268,6 +10268,15 @@ gatsby-legacy-polyfills@^0.0.2:
   dependencies:
     core-js-compat "^3.6.5"
 
+gatsby-link@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.4.3.tgz#e13b75ca86d172b7338761c9aa335f1746db3c4b"
+  integrity sha512-nQ9T9T91TxPIuf0HuHxTQ/oFjXg0hi4tF39X8IjWj7YNk4kKct0l2Jaztk/RzsZ930x6AtgGt6x6ukWic4zQKQ==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    "@types/reach__router" "^1.3.3"
+    prop-types "^15.7.2"
+
 gatsby-link@^2.4.13:
   version "2.4.13"
   resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.4.13.tgz#018461021a775c97859fe3c8e1f5d593287def78"


### PR DESCRIPTION
There's a breaking change in 2.4.4 that's breaking all of our relative links from generic content pages. Pinning until we can investigate the cause.