### PR TITLE
WEBREF-123 ⬆️ gatsby-link upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.24.8",
     "gatsby-image": "^2.4.13",
-    "gatsby-link": "2.4.3",
+    "gatsby-link": "^2.6.1",
     "gatsby-plugin-layout": "^1.3.10",
     "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -22,7 +22,7 @@ export const Button: ButtonSignature = (
   if (hasToProp(props)) {
     const { as, ...anchorProps } = handleUrl(to!)
     return (
-      <StyledButton renderAs={as} {...anchorProps} {...props}>
+      <StyledButton renderAs={as} {...props} {...anchorProps}>
         {children}
       </StyledButton>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.3":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -4139,6 +4146,14 @@
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.5.tgz#14e1e981cccd3a5e50dc9e969a72de0b9d472f6d"
   integrity sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+
+"@types/reach__router@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.6.tgz#413417ce74caab331c70ce6a03a4c825188e4709"
+  integrity sha512-RHYataCUPQnt+GHoASyRLq6wmZ0n8jWlBW8Lxcwd30NN6vQfbmTeoSDfkgxO0S1lEzArp8OFDsq5KIs7FygjtA==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
@@ -10155,15 +10170,6 @@ gatsby-legacy-polyfills@^0.0.2:
   dependencies:
     core-js-compat "^3.6.5"
 
-gatsby-link@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.4.3.tgz#e13b75ca86d172b7338761c9aa335f1746db3c4b"
-  integrity sha512-nQ9T9T91TxPIuf0HuHxTQ/oFjXg0hi4tF39X8IjWj7YNk4kKct0l2Jaztk/RzsZ930x6AtgGt6x6ukWic4zQKQ==
-  dependencies:
-    "@babel/runtime" "^7.9.6"
-    "@types/reach__router" "^1.3.3"
-    prop-types "^15.7.2"
-
 gatsby-link@^2.4.13:
   version "2.4.13"
   resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.4.13.tgz#018461021a775c97859fe3c8e1f5d593287def78"
@@ -10171,6 +10177,15 @@ gatsby-link@^2.4.13:
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/reach__router" "^1.3.3"
+    prop-types "^15.7.2"
+
+gatsby-link@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.6.1.tgz#453cfe8791cfb2d1f8652d7ea3d9b987f1cafef7"
+  integrity sha512-IZrikPN2MS0qX1MXM8Uo8mPl3dGNnkqXnc1dWTbG07aXNd2tQQ3I+YVWEP+9mWDtxqYs1BE8n324X204fLLl5w==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/reach__router" "^1.3.6"
     prop-types "^15.7.2"
 
 gatsby-page-utils@^0.2.18:


### PR DESCRIPTION
Upgraded `gatsby-link`. In version `2.4.4`, gatsby [altered](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-link/CHANGELOG.md#244-2020-06-02) the way in which relative links were resolved, to match `@reach/router` functionality.

This broke our custom `Button` component. The prop passing in `Button` had two instances of the `to` prop, the altered one (with the prefixed `/`) was getting overridden by the initial `to` prop (potentially without the prefixed `/`). This broke certain links across the site.

Updated the `Button` component and resolved the `gatsby-link` version to latest.