### PR TITLE
WEBNEW-224 👽 Added second case for video render

### DIFF
--- a/src/genericContentPage/renderMethods.js
+++ b/src/genericContentPage/renderMethods.js
@@ -102,6 +102,7 @@ const renderSponsorSection = node => {
 export const renderEmbeddedEntry = node => {
   switch (node.data.target.sys.contentType.sys.id) {
     case 'video':
+    case 'youTubeVideo':
       return renderVideo(node)
     case 'button':
       return renderButton(node)


### PR DESCRIPTION
This is so that we may rename the reference upstream in CMS and repurpose the video model for another use.