### PR TITLE
Revert "WEBNEW-224 👽 Added second case for video render"

### DIFF
--- a/src/genericContentPage/renderMethods.js
+++ b/src/genericContentPage/renderMethods.js
@@ -102,7 +102,6 @@ const renderSponsorSection = node => {
 export const renderEmbeddedEntry = node => {
   switch (node.data.target.sys.contentType.sys.id) {
     case 'video':
-    case 'youTubeVideo':
       return renderVideo(node)
     case 'button':
       return renderButton(node)


### PR DESCRIPTION
Reverts PrideInLondon/pride-london-web#1822

The rename approach won't work - going to continue with the existing model and update the content we already have here.