### PR TITLE
WEBNEW-214 ✨ Blog article template page

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -169,3 +169,13 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
     })
   }
 }
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type ContentfulBlogArticle implements Node {
+      author: ContentfulTalentProfile
+    }
+  `
+  createTypes(typeDefs)
+}

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -1,9 +1,40 @@
 import styled from 'styled-components'
-import { space, SpaceProps } from 'styled-system'
+import {
+  compose,
+  flexbox,
+  layout,
+  space,
+  FlexboxProps,
+  LayoutProps,
+  SpaceProps,
+} from 'styled-system'
+import { RichText } from '../../components/richText'
+import { fontSizes } from '../../theme/fonts'
+import { mediaQueries } from '../../theme/mediaQueries'
 
-export const InfoWrapper = styled.div<SpaceProps>`
-  display: flex;
-  justify-content: center;
+export const InfoWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
+  ${compose(flexbox, layout, space)}
+`
 
-  ${space}
+export const TitleWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
+  ${compose(flexbox, layout, space)}
+`
+
+export const Content = styled(RichText)`
+  ol,
+  ul {
+    width: 100%;
+  }
+
+  > p:first-of-type {
+    font-size: ${fontSizes.body_lg};
+  }
+
+  ${mediaQueries.md} {
+    ol,
+    p,
+    ul {
+      max-width: 624px;
+    }
+  }
 `

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -19,11 +19,20 @@ export const CONTENT_PADDING_X = {
   md: 'xxl',
 } as const
 
-export const InfoWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
+export const InfoWrapper = styled.div.attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  marginTop: 'xxl',
+  marginBottom: 'lg',
+})<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
 `
 
-export const TitleWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
+export const TitleWrapper = styled.div.attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingX: { default: 'lg', md: 'xxl' },
+})<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
 `
 
@@ -52,8 +61,12 @@ export const Content = styled(RichText).attrs({ paddingX: CONTENT_PADDING_X })`
   }
 `
 
-export const AuthorWrapper = styled.div<
-  FlexboxProps & LayoutProps & SpaceProps
->`
+export const AuthorWrapper = styled.div.attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  marginTop: 'xxl',
+  marginBottom: { default: 'xl', md: 'xxl' },
+  paddingX: { default: 'lg', md: 'xxl' },
+})<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
 `

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { space, SpaceProps } from 'styled-system'
+
+export const InfoWrapper = styled.div<SpaceProps>`
+  display: flex;
+  justify-content: center;
+
+  ${space}
+`

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -11,8 +11,13 @@ import {
 import { RichText } from '../../components/richText'
 import { fontSizes } from '../../theme/fonts'
 import { mediaQueries } from '../../theme/mediaQueries'
+import { spacing } from '../../theme/space'
 
 export const MAX_CONTENT_WIDTH = 624
+export const CONTENT_PADDING_X = {
+  default: 'lg',
+  md: 'xxl',
+} as const
 
 export const InfoWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
@@ -22,9 +27,20 @@ export const TitleWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
 `
 
-export const Content = styled(RichText)`
+export const Content = styled(RichText).attrs({ paddingX: CONTENT_PADDING_X })`
   > p:first-of-type {
     font-size: ${fontSizes.body_lg};
+  }
+
+  /* RippedSection full-width image :( */
+  > section {
+    margin-left: -${spacing[CONTENT_PADDING_X.default]};
+    margin-right: -${spacing[CONTENT_PADDING_X.default]};
+
+    ${mediaQueries.md} {
+      margin-left: -${spacing[CONTENT_PADDING_X.md]};
+      margin-right: -${spacing[CONTENT_PADDING_X.md]};
+    }
   }
 
   ${mediaQueries.md} {

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -21,11 +21,6 @@ export const TitleWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
 `
 
 export const Content = styled(RichText)`
-  ol,
-  ul {
-    width: 100%;
-  }
-
   > p:first-of-type {
     font-size: ${fontSizes.body_lg};
   }

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -12,6 +12,8 @@ import { RichText } from '../../components/richText'
 import { fontSizes } from '../../theme/fonts'
 import { mediaQueries } from '../../theme/mediaQueries'
 
+export const MAX_CONTENT_WIDTH = 624
+
 export const InfoWrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   ${compose(flexbox, layout, space)}
 `
@@ -29,7 +31,13 @@ export const Content = styled(RichText)`
     ol,
     p,
     ul {
-      max-width: 624px;
+      max-width: ${MAX_CONTENT_WIDTH}px;
     }
   }
+`
+
+export const AuthorWrapper = styled.div<
+  FlexboxProps & LayoutProps & SpaceProps
+>`
+  ${compose(flexbox, layout, space)}
 `

--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -1,40 +1,15 @@
 import styled from 'styled-components'
-import {
-  compose,
-  flexbox,
-  layout,
-  space,
-  FlexboxProps,
-  LayoutProps,
-  SpaceProps,
-} from 'styled-system'
 import { RichText } from '../../components/richText'
 import { fontSizes } from '../../theme/fonts'
 import { mediaQueries } from '../../theme/mediaQueries'
 import { spacing } from '../../theme/space'
 
 export const MAX_CONTENT_WIDTH = 624
-export const CONTENT_PADDING_X = {
+
+const CONTENT_PADDING_X = {
   default: 'lg',
   md: 'xxl',
 } as const
-
-export const InfoWrapper = styled.div.attrs({
-  display: 'flex',
-  justifyContent: 'center',
-  marginTop: 'xxl',
-  marginBottom: 'lg',
-})<FlexboxProps & LayoutProps & SpaceProps>`
-  ${compose(flexbox, layout, space)}
-`
-
-export const TitleWrapper = styled.div.attrs({
-  display: 'flex',
-  justifyContent: 'center',
-  paddingX: { default: 'lg', md: 'xxl' },
-})<FlexboxProps & LayoutProps & SpaceProps>`
-  ${compose(flexbox, layout, space)}
-`
 
 export const Content = styled(RichText).attrs({ paddingX: CONTENT_PADDING_X })`
   > p:first-of-type {
@@ -59,14 +34,4 @@ export const Content = styled(RichText).attrs({ paddingX: CONTENT_PADDING_X })`
       max-width: ${MAX_CONTENT_WIDTH}px;
     }
   }
-`
-
-export const AuthorWrapper = styled.div.attrs({
-  display: 'flex',
-  justifyContent: 'center',
-  marginTop: 'xxl',
-  marginBottom: { default: 'xl', md: 'xxl' },
-  paddingX: { default: 'lg', md: 'xxl' },
-})<FlexboxProps & LayoutProps & SpaceProps>`
-  ${compose(flexbox, layout, space)}
 `

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -1,9 +1,31 @@
 import React from 'react'
+import Image from 'gatsby-image/withIEPolyfill'
+import { RippedSection } from '../../components/rippedSection'
+import { RipVariant } from '../../components/rippedSection/Rip.types'
+import { getImageForBreakpoint } from '../../utils/style-utils'
+import { getRandomInt } from '../../utils/number-utils'
+import { colors } from '../../theme/colors'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
 
 export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
-  data: { contentfulBlogArticle: article },
-}) => {
-  console.log('article: ', article)
-  return <h1>blah</h1>
-}
+  data: {
+    contentfulBlogArticle: { hero },
+  },
+}) => (
+  <>
+    <RippedSection
+      rips={{
+        bottom: {
+          color: colors.white,
+          variant: getRandomInt(1, 5) as RipVariant,
+        },
+      }}
+    >
+      <Image
+        fluid={getImageForBreakpoint(hero)}
+        style={{ width: '100%' }}
+        aria-hidden="true"
+      />
+    </RippedSection>
+  </>
+)

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -2,14 +2,24 @@ import React from 'react'
 import Image from 'gatsby-image/withIEPolyfill'
 import { RippedSection } from '../../components/rippedSection'
 import { RipVariant } from '../../components/rippedSection/Rip.types'
+import { Tag } from '../../components/tag'
+import { H2 } from '../../components/typography'
 import { getImageForBreakpoint } from '../../utils/style-utils'
 import { getRandomInt } from '../../utils/number-utils'
 import { colors } from '../../theme/colors'
+import { InfoWrapper } from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
+
+const getCategoryColor = (category: string) => {
+  switch (category) {
+    default:
+      return colors.mexicanPink
+  }
+}
 
 export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
   data: {
-    contentfulBlogArticle: { hero },
+    contentfulBlogArticle: { hero, category, title },
   },
 }) => (
   <>
@@ -27,5 +37,11 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
         aria-hidden="true"
       />
     </RippedSection>
+    <InfoWrapper marginTop="xxl" marginBottom="lg">
+      <Tag color={getCategoryColor(category)}>{category}</Tag>
+    </InfoWrapper>
+    <H2 as="h1" textAlign="center">
+      {title}
+    </H2>
   </>
 )

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -2,19 +2,14 @@ import React from 'react'
 import Image from 'gatsby-image/withIEPolyfill'
 import { RippedSection } from '../../components/rippedSection'
 import { RipVariant } from '../../components/rippedSection/Rip.types'
+import { Wrapper } from '../../components/wrapper'
 import { Tag } from '../../components/tag'
 import { H2 } from '../../components/typography'
 import { TalentProfile } from '../../components/talentProfile'
 import { getImageForBreakpoint } from '../../utils/style-utils'
 import { getRandomInt } from '../../utils/number-utils'
 import { colors } from '../../theme/colors'
-import {
-  MAX_CONTENT_WIDTH,
-  InfoWrapper,
-  TitleWrapper,
-  Content,
-  AuthorWrapper,
-} from './BlogArticlePage.styles'
+import { MAX_CONTENT_WIDTH, Content } from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
 
 const getCategoryColor = (category: string) => {
@@ -50,19 +45,34 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
         aria-hidden="true"
       />
     </RippedSection>
-    <InfoWrapper>
+    <Wrapper
+      display="flex"
+      justifyContent="center"
+      marginTop="xxl"
+      marginBottom="lg"
+    >
       <Tag color={getCategoryColor(category)}>{category}</Tag>
-    </InfoWrapper>
-    <TitleWrapper>
+    </Wrapper>
+    <Wrapper
+      display="flex"
+      justifyContent="center"
+      paddingX={{ default: 'lg', md: 'xxl' }}
+    >
       <H2 as="h1" textAlign="center" maxWidth={842}>
         {title}
       </H2>
-    </TitleWrapper>
+    </Wrapper>
     <Content document={json} />
     {author && (
-      <AuthorWrapper>
+      <Wrapper
+        display="flex"
+        justifyContent="center"
+        marginTop="xxl"
+        marginBottom={{ default: 'xl', md: 'xxl' }}
+        paddingX={{ default: 'lg', md: 'xxl' }}
+      >
         <TalentProfile type="author" {...author} maxWidth={MAX_CONTENT_WIDTH} />
-      </AuthorWrapper>
+      </Wrapper>
     )}
   </>
 )

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -4,10 +4,17 @@ import { RippedSection } from '../../components/rippedSection'
 import { RipVariant } from '../../components/rippedSection/Rip.types'
 import { Tag } from '../../components/tag'
 import { H2 } from '../../components/typography'
+import { TalentProfile } from '../../components/talentProfile'
 import { getImageForBreakpoint } from '../../utils/style-utils'
 import { getRandomInt } from '../../utils/number-utils'
 import { colors } from '../../theme/colors'
-import { InfoWrapper, TitleWrapper, Content } from './BlogArticlePage.styles'
+import {
+  MAX_CONTENT_WIDTH,
+  InfoWrapper,
+  TitleWrapper,
+  Content,
+  AuthorWrapper,
+} from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
 
 const getCategoryColor = (category: string) => {
@@ -24,6 +31,7 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
       category,
       title,
       content: { json },
+      author,
     },
   },
 }) => (
@@ -60,5 +68,16 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
       </H2>
     </TitleWrapper>
     <Content document={json} />
+    {author && (
+      <AuthorWrapper
+        display="flex"
+        justifyContent="center"
+        marginTop="xxl"
+        marginBottom={{ default: 'xl', md: 'xxl' }}
+        paddingX={{ default: 'lg', md: 'xxl' }}
+      >
+        <TalentProfile type="author" {...author} maxWidth={MAX_CONTENT_WIDTH} />
+      </AuthorWrapper>
+    )}
   </>
 )

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -10,8 +10,6 @@ import { colors } from '../../theme/colors'
 import { InfoWrapper, TitleWrapper, Content } from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
 
-const PADDING_X = { default: 'lg', md: 'xxl' }
-
 const getCategoryColor = (category: string) => {
   switch (category) {
     default:
@@ -52,17 +50,15 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
     >
       <Tag color={getCategoryColor(category)}>{category}</Tag>
     </InfoWrapper>
-    <TitleWrapper display="flex" justifyContent="center" paddingX={PADDING_X}>
+    <TitleWrapper
+      display="flex"
+      justifyContent="center"
+      paddingX={{ default: 'lg', md: 'xxl' }}
+    >
       <H2 as="h1" textAlign="center" maxWidth={842}>
         {title}
       </H2>
     </TitleWrapper>
-    <Content
-      document={json}
-      display="flex"
-      flexDirection="column"
-      alignItems="center"
-      paddingX={PADDING_X}
-    />
+    <Content document={json} />
   </>
 )

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { BlogArticlePageProps } from './BlogArticlePage.types'
+
+export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
+  data: { contentfulBlogArticle: article },
+}) => {
+  console.log('article: ', article)
+  return <h1>blah</h1>
+}

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -7,8 +7,10 @@ import { H2 } from '../../components/typography'
 import { getImageForBreakpoint } from '../../utils/style-utils'
 import { getRandomInt } from '../../utils/number-utils'
 import { colors } from '../../theme/colors'
-import { InfoWrapper } from './BlogArticlePage.styles'
+import { InfoWrapper, TitleWrapper, Content } from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
+
+const PADDING_X = { default: 'lg', md: 'xxl' }
 
 const getCategoryColor = (category: string) => {
   switch (category) {
@@ -19,7 +21,12 @@ const getCategoryColor = (category: string) => {
 
 export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
   data: {
-    contentfulBlogArticle: { hero, category, title },
+    contentfulBlogArticle: {
+      hero,
+      category,
+      title,
+      content: { json },
+    },
   },
 }) => (
   <>
@@ -37,11 +44,25 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
         aria-hidden="true"
       />
     </RippedSection>
-    <InfoWrapper marginTop="xxl" marginBottom="lg">
+    <InfoWrapper
+      display="flex"
+      justifyContent="center"
+      marginTop="xxl"
+      marginBottom="lg"
+    >
       <Tag color={getCategoryColor(category)}>{category}</Tag>
     </InfoWrapper>
-    <H2 as="h1" textAlign="center">
-      {title}
-    </H2>
+    <TitleWrapper display="flex" justifyContent="center" paddingX={PADDING_X}>
+      <H2 as="h1" textAlign="center" maxWidth={842}>
+        {title}
+      </H2>
+    </TitleWrapper>
+    <Content
+      document={json}
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      paddingX={PADDING_X}
+    />
   </>
 )

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -50,32 +50,17 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
         aria-hidden="true"
       />
     </RippedSection>
-    <InfoWrapper
-      display="flex"
-      justifyContent="center"
-      marginTop="xxl"
-      marginBottom="lg"
-    >
+    <InfoWrapper>
       <Tag color={getCategoryColor(category)}>{category}</Tag>
     </InfoWrapper>
-    <TitleWrapper
-      display="flex"
-      justifyContent="center"
-      paddingX={{ default: 'lg', md: 'xxl' }}
-    >
+    <TitleWrapper>
       <H2 as="h1" textAlign="center" maxWidth={842}>
         {title}
       </H2>
     </TitleWrapper>
     <Content document={json} />
     {author && (
-      <AuthorWrapper
-        display="flex"
-        justifyContent="center"
-        marginTop="xxl"
-        marginBottom={{ default: 'xl', md: 'xxl' }}
-        paddingX={{ default: 'lg', md: 'xxl' }}
-      >
+      <AuthorWrapper>
         <TalentProfile type="author" {...author} maxWidth={MAX_CONTENT_WIDTH} />
       </AuthorWrapper>
     )}

--- a/src/blog/article/BlogArticlePage.types.ts
+++ b/src/blog/article/BlogArticlePage.types.ts
@@ -1,0 +1,24 @@
+import { Document } from '@contentful/rich-text-types'
+import { ContentfulTalentProfile } from '../../components/talentProfile/TalentProfile.types'
+
+interface ContentfulBlogArticle {
+  hero: {
+    image: {
+      file: {
+        url: string
+      }
+    }
+  }
+  category: string
+  title: string
+  content: {
+    json: Document
+  }
+  author: ContentfulTalentProfile
+}
+
+export interface BlogArticlePageProps {
+  data: {
+    contentfulBlogArticle: ContentfulBlogArticle
+  }
+}

--- a/src/blog/article/BlogArticlePage.types.ts
+++ b/src/blog/article/BlogArticlePage.types.ts
@@ -1,13 +1,12 @@
 import { Document } from '@contentful/rich-text-types'
+import { FluidObject } from 'gatsby-image'
 import { ContentfulTalentProfile } from '../../components/talentProfile/TalentProfile.types'
 
 interface ContentfulBlogArticle {
   hero: {
-    image: {
-      file: {
-        url: string
-      }
-    }
+    desktop: FluidObject
+    tablet: FluidObject
+    mobile: FluidObject
   }
   category: string
   title: string

--- a/src/components/quote/Quote.styles.tsx
+++ b/src/components/quote/Quote.styles.tsx
@@ -3,5 +3,7 @@ import { compose, layout, space } from 'styled-system'
 import { H3 } from '../typography'
 
 export const StyledBlockquote = styled(H3)`
+  margin: 0;
+
   ${compose(space, layout)}
 `

--- a/src/components/quote/Quote.tsx
+++ b/src/components/quote/Quote.tsx
@@ -2,10 +2,8 @@ import React from 'react'
 import { QuoteProps } from './Quote.types'
 import { StyledBlockquote } from './Quote.styles'
 
-export const Quote: React.FC<QuoteProps> = ({ children, ...props }) => {
-  return (
-    <StyledBlockquote as="blockquote" textAlign="center" {...props}>
-      "{children}"
-    </StyledBlockquote>
-  )
-}
+export const Quote: React.FC<QuoteProps> = ({ children, ...props }) => (
+  <StyledBlockquote as="blockquote" textAlign="center" {...props}>
+    "{children}"
+  </StyledBlockquote>
+)

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { compose, layout, space } from 'styled-system'
+import { compose, flexbox, layout, space } from 'styled-system'
 import { colors } from '../../theme/colors'
 import { md } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
@@ -17,7 +17,7 @@ export const Wrapper = styled.div`
     }
   }
 
-  ${compose(layout, space)}
+  ${compose(flexbox, layout, space)}
 `
 
 export const MultiImageWrapper = styled.div`

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { compose, flexbox, layout, space } from 'styled-system'
+import { compose, flexbox, layout, space, SpaceProps } from 'styled-system'
 import { colors } from '../../theme/colors'
 import { md } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
@@ -22,7 +22,7 @@ export const Wrapper = styled.div`
   ${compose(flexbox, layout, space)}
 `
 
-export const MultiImageWrapper = styled.div`
+export const MultiImageWrapper = styled.div<SpaceProps>`
   display: grid;
   grid-template-rows: repeat(3, 1fr);
   grid-template-columns: 1fr;
@@ -33,6 +33,8 @@ export const MultiImageWrapper = styled.div`
     grid-template-columns: repeat(3, 1fr);
     column-gap: ${md}px;
   }
+
+  ${space}
 `
 
 export const Hyperlink = styled(Navigate)`

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -9,11 +9,20 @@ import {
   SpaceProps,
 } from 'styled-system'
 import { colors } from '../../theme/colors'
-import { md } from '../../theme/space'
+import { md, spacing } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
 import { Navigate } from '../navigate'
 
-export const Wrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
+export const CONTENT_PADDING_X = {
+  default: 'lg',
+  md: 'xxl',
+} as const
+
+export const Wrapper = styled.div.attrs<
+  FlexboxProps & LayoutProps & SpaceProps
+>({
+  paddingX: CONTENT_PADDING_X,
+})`
   li {
     color: ${colors.indigo};
   }
@@ -27,9 +36,20 @@ export const Wrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
     }
   }
 
-  blockquote {
+  > blockquote {
     > p {
       all: unset;
+    }
+  }
+
+  /* RippedSection full-width image :( */
+  > section {
+    margin-left: -${spacing[CONTENT_PADDING_X.default]};
+    margin-right: -${spacing[CONTENT_PADDING_X.default]};
+
+    ${mediaQueries.md} {
+      margin-left: -${spacing[CONTENT_PADDING_X.md]};
+      margin-right: -${spacing[CONTENT_PADDING_X.md]};
     }
   }
 

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -10,8 +10,10 @@ export const Wrapper = styled.div`
     color: ${colors.indigo};
   }
 
-  ul,
-  ol {
+  ol,
+  ul {
+    width: 100%;
+
     p {
       margin: 0;
     }

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -19,6 +19,12 @@ export const Wrapper = styled.div`
     }
   }
 
+  blockquote {
+    > p {
+      all: unset;
+    }
+  }
+
   ${compose(flexbox, layout, space)}
 `
 

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -9,20 +9,11 @@ import {
   SpaceProps,
 } from 'styled-system'
 import { colors } from '../../theme/colors'
-import { md, spacing } from '../../theme/space'
+import { md } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
 import { Navigate } from '../navigate'
 
-export const CONTENT_PADDING_X = {
-  default: 'lg',
-  md: 'xxl',
-} as const
-
-export const Wrapper = styled.div.attrs<
-  FlexboxProps & LayoutProps & SpaceProps
->({
-  paddingX: CONTENT_PADDING_X,
-})`
+export const Wrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   li {
     color: ${colors.indigo};
   }
@@ -39,17 +30,6 @@ export const Wrapper = styled.div.attrs<
   > blockquote {
     > p {
       all: unset;
-    }
-  }
-
-  /* RippedSection full-width image :( */
-  > section {
-    margin-left: -${spacing[CONTENT_PADDING_X.default]};
-    margin-right: -${spacing[CONTENT_PADDING_X.default]};
-
-    ${mediaQueries.md} {
-      margin-left: -${spacing[CONTENT_PADDING_X.md]};
-      margin-right: -${spacing[CONTENT_PADDING_X.md]};
     }
   }
 

--- a/src/components/richText/RichText.styles.ts
+++ b/src/components/richText/RichText.styles.ts
@@ -1,11 +1,19 @@
 import styled from 'styled-components'
-import { compose, flexbox, layout, space, SpaceProps } from 'styled-system'
+import {
+  compose,
+  flexbox,
+  layout,
+  space,
+  FlexboxProps,
+  LayoutProps,
+  SpaceProps,
+} from 'styled-system'
 import { colors } from '../../theme/colors'
 import { md } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
 import { Navigate } from '../navigate'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   li {
     color: ${colors.indigo};
   }
@@ -28,7 +36,7 @@ export const Wrapper = styled.div`
   ${compose(flexbox, layout, space)}
 `
 
-export const MultiImageWrapper = styled.div<SpaceProps>`
+export const MultiImageWrapper = styled.div<LayoutProps & SpaceProps>`
   display: grid;
   grid-template-rows: repeat(3, 1fr);
   grid-template-columns: 1fr;
@@ -40,7 +48,7 @@ export const MultiImageWrapper = styled.div<SpaceProps>`
     column-gap: ${md}px;
   }
 
-  ${space}
+  ${compose(layout, space)}
 `
 
 export const Hyperlink = styled(Navigate)`

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -5,7 +5,7 @@ import { Wrapper } from './RichText.styles'
 import { RichTextProps } from './RichText.types'
 
 export const RichText: React.FC<RichTextProps> = ({ document, ...props }) => (
-  <Wrapper {...props}>
+  <Wrapper display="flex" flexDirection="column" alignItems="center" {...props}>
     {documentToReactComponents(document, renderMethods)}
   </Wrapper>
 )

--- a/src/components/richText/RichText.types.ts
+++ b/src/components/richText/RichText.types.ts
@@ -1,5 +1,5 @@
 import { Document } from '@contentful/rich-text-types'
-import { LayoutProps, SpaceProps } from 'styled-system'
+import { FlexboxProps, LayoutProps, SpaceProps } from 'styled-system'
 
 export interface ContentfulImage {
   fields: {
@@ -20,6 +20,6 @@ export interface ContentfulImage {
   }
 }
 
-export interface RichTextProps extends LayoutProps, SpaceProps {
+export interface RichTextProps extends FlexboxProps, LayoutProps, SpaceProps {
   document: Document
 }

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { NodeRenderer, Options } from '@contentful/rich-text-react-renderer'
 import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 import { colors } from '../../theme/colors'
+import { lg, xxl } from '../../theme/space'
 import { getRandomInt } from '../../utils/number-utils'
 import { RippedSection } from '../rippedSection'
 import { Rip, RipVariant } from '../rippedSection/Rip.types'
@@ -114,7 +115,14 @@ export const renderEmbeddedEntry: NodeRenderer = (node, children) => {
 
 const renderParagraph: NodeRenderer = (_node, children) => <P>{children}</P>
 
-const renderQuote: NodeRenderer = (_node, children) => <Quote>{children}</Quote>
+const renderQuote: NodeRenderer = (_node, children) => (
+  <Quote
+    marginY={{ default: 'xxl', md: (lg + xxl).toString() }}
+    maxWidth={1062}
+  >
+    {children}
+  </Quote>
+)
 
 const renderHyperlink: NodeRenderer = ({ data: { uri } }, children) => (
   <Hyperlink to={uri}>{children}</Hyperlink>

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -81,9 +81,10 @@ const renderMultiImage: NodeRenderer = (
     maxWidth={MAX_CONTENT_WIDTH}
   >
     {getAnyForLocale<ContentfulImage[]>(images).map(
-      (props: ContentfulImage) => (
-        <Image {...getImageForLocale(props)} />
-      )
+      (props: ContentfulImage) => {
+        const imageProps = getImageForLocale(props)
+        return <Image key={imageProps.src} {...imageProps} />
+      }
     )}
   </MultiImageWrapper>
 )

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -58,6 +58,7 @@ const renderImage: NodeRenderer = ({ data: { target } }, _children) => {
         top: generateRip(),
         bottom: generateRip(),
       }}
+      marginY={{ default: 'xxl', md: `${lg + xxl}px` }}
     >
       <img {...props} width="100%" />
     </RippedSection>

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -123,7 +123,7 @@ const renderParagraph: NodeRenderer = (_node, children) => <P>{children}</P>
 
 const renderQuote: NodeRenderer = (_node, children) => (
   <Quote
-    marginY={{ default: 'xxl', md: (lg + xxl).toString() }}
+    marginY={{ default: 'xxl', md: `${lg + xxl}px` }}
     maxWidth={MAX_CONTENT_WIDTH}
   >
     {children}

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -105,7 +105,13 @@ const renderVideo: NodeRenderer = (
     caption: getStringForLocale(caption),
     coverImage: getImageForLocale(getAnyForLocale(image)),
   }
-  return <Video {...props} />
+  return (
+    <Video
+      marginY={{ default: 'xl', md: 'xxl' }}
+      maxWidth={MAX_CONTENT_WIDTH}
+      {...props}
+    />
+  )
 }
 
 export const renderEmbeddedEntry: NodeRenderer = (node, children) => {

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -68,7 +68,7 @@ const renderMultiImage: NodeRenderer = (
   },
   _children
 ) => (
-  <MultiImageWrapper>
+  <MultiImageWrapper marginY={{ default: 'xl', md: 'xxl' }}>
     {getAnyForLocale<ContentfulImage[]>(images).map(
       (props: ContentfulImage) => (
         <Image {...getImageForLocale(props)} />

--- a/src/components/richText/renderMethods.tsx
+++ b/src/components/richText/renderMethods.tsx
@@ -16,6 +16,8 @@ import { ContentfulImage } from './RichText.types'
 
 export const DEFAULT_LOCALE = 'en-GB'
 
+const MAX_CONTENT_WIDTH = 1062
+
 export const getAnyForLocale = <T,>(
   val: { [key: string]: T },
   locale = DEFAULT_LOCALE
@@ -73,7 +75,10 @@ const renderMultiImage: NodeRenderer = (
   },
   _children
 ) => (
-  <MultiImageWrapper marginY={{ default: 'xl', md: 'xxl' }}>
+  <MultiImageWrapper
+    marginY={{ default: 'xl', md: 'xxl' }}
+    maxWidth={MAX_CONTENT_WIDTH}
+  >
     {getAnyForLocale<ContentfulImage[]>(images).map(
       (props: ContentfulImage) => (
         <Image {...getImageForLocale(props)} />
@@ -118,7 +123,7 @@ const renderParagraph: NodeRenderer = (_node, children) => <P>{children}</P>
 const renderQuote: NodeRenderer = (_node, children) => (
   <Quote
     marginY={{ default: 'xxl', md: (lg + xxl).toString() }}
-    maxWidth={1062}
+    maxWidth={MAX_CONTENT_WIDTH}
   >
     {children}
   </Quote>

--- a/src/components/rippedSection/RippedSection.styles.tsx
+++ b/src/components/rippedSection/RippedSection.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { layout } from 'styled-system'
+import { compose, layout, space } from 'styled-system'
 
 export const StyledSection = styled.section`
   position: relative;
@@ -7,5 +7,5 @@ export const StyledSection = styled.section`
   align-items: center;
   justify-content: center;
 
-  ${layout}
+  ${compose(layout, space)}
 `

--- a/src/components/rippedSection/RippedSection.types.ts
+++ b/src/components/rippedSection/RippedSection.types.ts
@@ -1,7 +1,7 @@
-import { LayoutProps } from 'styled-system'
+import { LayoutProps, SpaceProps } from 'styled-system'
 import { Rip } from './Rip.types'
 
-export interface RippedSectionProps extends LayoutProps {
+export interface RippedSectionProps extends LayoutProps, SpaceProps {
   rips?: {
     top?: Rip
     bottom?: Rip

--- a/src/components/talentProfile/TalentProfile.styles.ts
+++ b/src/components/talentProfile/TalentProfile.styles.ts
@@ -7,10 +7,6 @@ export const Wrapper = styled.div<LayoutProps & SpaceProps>`
   background-color: ${colors.lightGrey};
   padding: ${xl_mob}px ${lg}px;
 
-  > div {
-    padding: 0;
-  }
-
   ${compose(layout, space)}
 `
 

--- a/src/components/talentProfile/TalentProfile.styles.ts
+++ b/src/components/talentProfile/TalentProfile.styles.ts
@@ -7,6 +7,10 @@ export const Wrapper = styled.div<LayoutProps & SpaceProps>`
   background-color: ${colors.lightGrey};
   padding: ${xl_mob}px ${lg}px;
 
+  > div {
+    padding: 0;
+  }
+
   ${compose(layout, space)}
 `
 

--- a/src/components/talentProfile/TalentProfile.types.ts
+++ b/src/components/talentProfile/TalentProfile.types.ts
@@ -11,8 +11,7 @@ export interface SocialLinkProps extends SocialProps {
   talentType: string
 }
 
-export interface TalentProfileProps extends SpaceProps, LayoutProps {
-  type: string
+export interface ContentfulTalentProfile {
   bio: {
     json: Document
   }
@@ -21,4 +20,10 @@ export interface TalentProfileProps extends SpaceProps, LayoutProps {
   email?: string
   facebook?: string
   twitter?: string
+}
+export interface TalentProfileProps
+  extends ContentfulTalentProfile,
+    SpaceProps,
+    LayoutProps {
+  type: string
 }

--- a/src/components/talentProfile/TalentProfile.types.ts
+++ b/src/components/talentProfile/TalentProfile.types.ts
@@ -21,6 +21,7 @@ export interface ContentfulTalentProfile {
   facebook?: string
   twitter?: string
 }
+
 export interface TalentProfileProps
   extends ContentfulTalentProfile,
     SpaceProps,

--- a/src/components/wrapper/index.ts
+++ b/src/components/wrapper/index.ts
@@ -1,0 +1,1 @@
+export { Wrapper } from './Wrapper'

--- a/src/layout/Layout.styles.js
+++ b/src/layout/Layout.styles.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components'
 import { colors } from '../theme/colors'
+import { max } from '../theme/breakpoints'
 
 export const SiteWrapper = styled.div`
-  max-width: 1600px;
+  max-width: ${max}px;
   margin: 0 auto;
   background-color: ${colors.white};
 `

--- a/src/theme/breakpoints.ts
+++ b/src/theme/breakpoints.ts
@@ -3,6 +3,7 @@ export const md = 768
 export const lg = 1024
 export const xl = 1440
 export const nav = 1360
+export const max = 1600
 
 export interface Breakpoints {
   sm: string

--- a/src/utils/style-utils.ts
+++ b/src/utils/style-utils.ts
@@ -1,4 +1,4 @@
-import { FixedObject } from 'gatsby-image'
+import { FixedObject, FluidObject } from 'gatsby-image'
 import { sm, md } from '../theme/breakpoints'
 
 export const checkBreakpoint = (breakpoint: number): boolean =>
@@ -18,12 +18,13 @@ export const noScroll = {
   },
 }
 
-export const getImageForBreakpoint = ({
+export const getImageForBreakpoint = <T extends FluidObject | FixedObject>({
   mobile,
   tablet,
   desktop,
 }: {
-  mobile: FixedObject
-  tablet: FixedObject
-  desktop: FixedObject
-}) => (!checkBreakpoint(sm) ? mobile : !checkBreakpoint(md) ? tablet : desktop)
+  mobile: T
+  tablet: T
+  desktop: T
+}): T =>
+  !checkBreakpoint(sm) ? mobile : !checkBreakpoint(md) ? tablet : desktop


### PR DESCRIPTION
This is the first PR for the template page (minus the `You May Also Like` section and `ShareBar`). This is not currently linked up to the CMS, so to be tested locally a fake page and query can be added:

```
query blogArticleQuery {
    contentfulBlogArticle(id: { eq: "<CONTENTFUL_ENTRY_ID>" }) {
      hero {
        desktop: fluid(maxWidth: 1600, quality: 100) {
          ...GatsbyContentfulFluid_withWebp
        }
        tablet: fluid(maxWidth: 768, quality: 100) {
          ...GatsbyContentfulFluid_withWebp
        }
        mobile: fluid(maxWidth: 375, quality: 100) {
          ...GatsbyContentfulFluid_withWebp
        }
      }
      category
      title
      content {
        json
      }
      author {
        bio {
          json
        }
        website
        email
        facebook
        twitter
        instagram
      }
    }
  }
```