### PR TITLE
WEBNEW-228 ✨ Blog article share bar

### DIFF
--- a/src/blog/article/BlogArticlePage.styles.ts
+++ b/src/blog/article/BlogArticlePage.styles.ts
@@ -13,7 +13,11 @@ const CONTENT_PADDING_X = {
 
 export const Content = styled(RichText).attrs({ paddingX: CONTENT_PADDING_X })`
   > p:first-of-type {
-    font-size: ${fontSizes.body_lg};
+    font-size: ${fontSizes.body_md};
+
+    ${mediaQueries.md} {
+      font-size: ${fontSizes.body_lg};
+    }
   }
 
   /* RippedSection full-width image :( */

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -5,6 +5,7 @@ import { RipVariant } from '../../components/rippedSection/Rip.types'
 import { Wrapper } from '../../components/wrapper'
 import { Tag } from '../../components/tag'
 import { H2 } from '../../components/typography'
+import { ShareBar } from '../../components/shareBar'
 import { TalentProfile } from '../../components/talentProfile'
 import { getImageForBreakpoint } from '../../utils/style-utils'
 import { getRandomInt } from '../../utils/number-utils'
@@ -55,13 +56,28 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
     </Wrapper>
     <Wrapper
       display="flex"
+      flexDirection="column"
+      alignItems="center"
       justifyContent="center"
       paddingX={{ default: 'lg', md: 'xxl' }}
+      position="relative"
     >
       <H2 as="h1" textAlign="center" maxWidth={842}>
         {title}
       </H2>
+      <Wrapper
+        position={{ md: 'absolute' }}
+        marginBottom={{ default: 'xl_mob', md: '0' }}
+        top={{ md: 0 }}
+        left={{ md: 'lg' }}
+      >
+        <ShareBar
+          variant={{ default: 'horizontal', md: 'vertical' }}
+          content={{ title, body: '', url: '' }}
+        />
+      </Wrapper>
     </Wrapper>
+
     <Content document={json} />
     {author && (
       <Wrapper

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -8,6 +8,7 @@ import { H2 } from '../../components/typography'
 import { ShareBar } from '../../components/shareBar'
 import { TalentProfile } from '../../components/talentProfile'
 import { getImageForBreakpoint } from '../../utils/style-utils'
+import { getFirstParagraph } from '../../utils/document-utils'
 import { getRandomInt } from '../../utils/number-utils'
 import { colors } from '../../theme/colors'
 import { MAX_CONTENT_WIDTH, Content } from './BlogArticlePage.styles'
@@ -74,7 +75,7 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
       >
         <ShareBar
           variant={{ default: 'horizontal', md: 'vertical' }}
-          content={{ title, body: '', url: href }}
+          content={{ title, body: getFirstParagraph(json), url: href }}
         />
       </Wrapper>
     </Wrapper>

--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -30,6 +30,7 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
       author,
     },
   },
+  location: { href },
 }) => (
   <>
     <RippedSection
@@ -73,11 +74,10 @@ export const BlogArticlePage: React.FC<BlogArticlePageProps> = ({
       >
         <ShareBar
           variant={{ default: 'horizontal', md: 'vertical' }}
-          content={{ title, body: '', url: '' }}
+          content={{ title, body: '', url: href }}
         />
       </Wrapper>
     </Wrapper>
-
     <Content document={json} />
     {author && (
       <Wrapper

--- a/src/blog/article/BlogArticlePage.types.ts
+++ b/src/blog/article/BlogArticlePage.types.ts
@@ -20,4 +20,5 @@ export interface BlogArticlePageProps {
   data: {
     contentfulBlogArticle: ContentfulBlogArticle
   }
+  location: Location
 }

--- a/src/blog/article/PageContent.styles.tsx
+++ b/src/blog/article/PageContent.styles.tsx
@@ -1,31 +1,27 @@
 import styled from 'styled-components'
 import { ShareBar } from '../../components/shareBar'
-import { space } from '../../theme/space'
+import { lg, xxl } from '../../theme/space'
 import { mediaQueries } from '../../theme/mediaQueries'
 
 export const ShareBarWrapper = styled.div`
   display: none;
   position: absolute;
-  top: -${space.xxl};
-  left: ${space.lg};
-  margin-top: 100px;
+  top: -${xxl}px;
+  left: ${lg}px;
+  margin-top: 48px;
   margin-left: -55px;
   height: 100%;
   z-index: 1;
 
   ${mediaQueries.lg} {
     display: block;
-    left: 60px;
-  }
-
-  ${mediaQueries.xl} {
-    display: block;
-    left: ${space.xxl};
+    left: ${xxl}px;
   }
 `
+
 export const DesktopShareBar = styled(ShareBar)`
-  top: 100px;
-  margin-top: 45px;
+  top: ${lg}px;
+  margin-top: ${lg}px;
   margin-bottom: 120px;
   position: sticky;
 `

--- a/src/campaigns/youMeUsWe/CelebrateYourCommunitySection.tsx
+++ b/src/campaigns/youMeUsWe/CelebrateYourCommunitySection.tsx
@@ -29,7 +29,7 @@ const CelebrateYourCommunitySection = () => (
         marginBottom={{ md: '0', default: 'xl' }}
       />
     </Typeform>
-    <MobileShareBar variant="horizontal" />
+    <MobileShareBar />
   </SectionWrapper>
 )
 

--- a/src/campaigns/youMeUsWe/PrideInLockdownSection.tsx
+++ b/src/campaigns/youMeUsWe/PrideInLockdownSection.tsx
@@ -8,7 +8,7 @@ import ymuw from './assets/ymuw.jpg'
 const PrideInLockdownSection = () => (
   <SectionWrapper>
     <Heading as="h2">Pride in Lockdown</Heading>
-    <MobileShareBar variant="horizontal" />
+    <MobileShareBar />
     <P variant="lg" marginTop={{ md: '0', default: 'xl' }}>
       Every year the capital sees over a million volunteers, artists and
       Pride-goers come together, united in their support of the LGBT+ community.

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
@@ -36,18 +36,14 @@ export const BannerMark = styled(Mark)`
 export const DesktopShareBar = styled(ShareBar).attrs({
   content,
   variant: 'vertical',
+  left: 'lg',
+  position: 'absolute',
+  top: '165px',
 })`
   display: none;
-  position: absolute;
-  top: 165px;
-  left: ${lg}px;
 
   ${mediaQueries.md} {
-    display: block;
-  }
-
-  ${mediaQueries.lg} {
-    left: 90px;
+    display: inline-block;
   }
 `
 

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
@@ -33,7 +33,10 @@ export const BannerMark = styled(Mark)`
   }
 `
 
-export const DesktopShareBar = styled(ShareBar).attrs({ content })`
+export const DesktopShareBar = styled(ShareBar).attrs({
+  content,
+  variant: 'vertical',
+})`
   display: none;
   position: absolute;
   top: 165px;
@@ -48,7 +51,10 @@ export const DesktopShareBar = styled(ShareBar).attrs({ content })`
   }
 `
 
-export const MobileShareBar = styled(ShareBar).attrs({ content })`
+export const MobileShareBar = styled(ShareBar).attrs({
+  content,
+  variant: 'horizontal',
+})`
   display: block;
 
   ${mediaQueries.md} {

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
@@ -37,12 +37,16 @@ export const DesktopShareBarWrapper = styled.div`
   display: none;
   position: absolute;
   top: 150px;
-  left: 90px;
+  left: ${lg}px;
   height: 100%;
   z-index: 1;
 
   ${mediaQueries.md} {
     display: block;
+  }
+
+  ${mediaQueries.lg} {
+    left: 90px;
   }
 `
 

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.styles.tsx
@@ -33,13 +33,11 @@ export const BannerMark = styled(Mark)`
   }
 `
 
-export const DesktopShareBarWrapper = styled.div`
+export const DesktopShareBar = styled(ShareBar).attrs({ content })`
   display: none;
   position: absolute;
-  top: 150px;
+  top: 165px;
   left: ${lg}px;
-  height: 100%;
-  z-index: 1;
 
   ${mediaQueries.md} {
     display: block;
@@ -48,11 +46,6 @@ export const DesktopShareBarWrapper = styled.div`
   ${mediaQueries.lg} {
     left: 90px;
   }
-`
-
-export const DesktopShareBar = styled(ShareBar).attrs({ content })`
-  top: 90px;
-  margin-bottom: 120px;
 `
 
 export const MobileShareBar = styled(ShareBar).attrs({ content })`

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.tsx
@@ -29,7 +29,7 @@ const YouMeUsWePage = (props: YouMeUsWePageProps) => (
       <BannerMark />
     </BannerBackgroundImage>
     <Wrapper>
-      <DesktopShareBar variant="vertical" />
+      <DesktopShareBar />
       <StyledTag color={colors.yellow}>Pride in London Themes</StyledTag>
       <PrideInLockdownSection />
       <ActsOfAllyshipSection />

--- a/src/campaigns/youMeUsWe/YouMeUsWePage.tsx
+++ b/src/campaigns/youMeUsWe/YouMeUsWePage.tsx
@@ -4,7 +4,6 @@ import YouMeUsWePageHelmet from './YouMeUsWePageHelmet'
 import {
   BannerBackgroundImage,
   BannerMark,
-  DesktopShareBarWrapper,
   DesktopShareBar,
   Wrapper,
   StyledTag,
@@ -30,9 +29,7 @@ const YouMeUsWePage = (props: YouMeUsWePageProps) => (
       <BannerMark />
     </BannerBackgroundImage>
     <Wrapper>
-      <DesktopShareBarWrapper>
-        <DesktopShareBar variant="vertical" />
-      </DesktopShareBarWrapper>
+      <DesktopShareBar variant="vertical" />
       <StyledTag color={colors.yellow}>Pride in London Themes</StyledTag>
       <PrideInLockdownSection />
       <ActsOfAllyshipSection />

--- a/src/components/shareBar/ShareBar.stories.tsx
+++ b/src/components/shareBar/ShareBar.stories.tsx
@@ -1,24 +1,22 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { text } from '@storybook/addon-knobs'
+import { select, text } from '@storybook/addon-knobs'
 import { ShareBar } from './ShareBar'
+import { VARIANTS } from './ShareBar.types'
 
-const CONTENT = 'Content'
+const CONTENT_GROUP_ID = 'Content'
 
-const dynamicContent = () => ({
-  title: text('Title', 'Pride in London', CONTENT),
-  body: text(
-    'Body',
-    'The UK’s biggest, most diverse Pride. A home for every part of London’s LGBT+ community',
-    CONTENT
-  ),
-  url: text('URL', 'http://prideinlondon.org', CONTENT),
-})
-
-storiesOf('ShareBar', module)
-  .add('horizontal', () => (
-    <ShareBar variant="horizontal" content={dynamicContent()} />
-  ))
-  .add('vertical', () => (
-    <ShareBar variant="vertical" content={dynamicContent()} />
-  ))
+storiesOf('ShareBar', module).add('default', () => (
+  <ShareBar
+    variant={select('variant', VARIANTS, VARIANTS[0])}
+    content={{
+      title: text('Title', 'Pride in London', CONTENT_GROUP_ID),
+      body: text(
+        'Body',
+        'The UK’s biggest, most diverse Pride. A home for every part of London’s LGBT+ community',
+        CONTENT_GROUP_ID
+      ),
+      url: text('URL', 'http://prideinlondon.org', CONTENT_GROUP_ID),
+    }}
+  />
+))

--- a/src/components/shareBar/ShareBar.stories.tsx
+++ b/src/components/shareBar/ShareBar.stories.tsx
@@ -16,7 +16,7 @@ storiesOf('ShareBar', module).add('default', () => (
         'The UK’s biggest, most diverse Pride. A home for every part of London’s LGBT+ community',
         CONTENT_GROUP_ID
       ),
-      url: text('URL', 'http://prideinlondon.org', CONTENT_GROUP_ID),
+      url: text('URL', 'https://prideinlondon.org', CONTENT_GROUP_ID),
     }}
   />
 ))

--- a/src/components/shareBar/ShareBar.styles.tsx
+++ b/src/components/shareBar/ShareBar.styles.tsx
@@ -53,12 +53,14 @@ export const SocialsWrapper = styled(Wrapper).attrs({
     variants: {
       horizontal: {
         flexDirection: 'row',
+        marginTop: 0,
         marginLeft: 'sm',
       },
       vertical: {
         flexDirection: 'column',
         transform: 'translateY(22px)',
         marginTop: 'sm',
+        marginLeft: 0,
       },
     },
   })}

--- a/src/components/shareBar/ShareBar.styles.tsx
+++ b/src/components/shareBar/ShareBar.styles.tsx
@@ -1,14 +1,15 @@
 import styled from 'styled-components'
 import { variant } from 'styled-system'
-import { colors } from '../../theme/colors'
-import { fonts } from '../../theme/fonts'
 import { sm } from '../../theme/space'
+import { H6 } from '../typography'
+import { Wrapper } from '../wrapper'
 
-export const Flex = styled.div`
-  font-size: 2em;
-  display: flex;
-  line-height: 1em;
-
+export const Flex = styled(Wrapper).attrs({
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '2em',
+  lineHeight: '1em',
+})`
   ${variant({
     variants: {
       horizontal: {
@@ -36,12 +37,7 @@ export const Flex = styled.div`
   }
 `
 
-export const ShareText = styled.h6`
-  font-family: ${fonts.title};
-  font-weight: 800;
-  vertical-align: middle;
-  color: ${colors.indigo};
-
+export const ShareText = styled(H6).attrs({ mb: 0 })`
   ${variant({
     variants: {
       vertical: {

--- a/src/components/shareBar/ShareBar.styles.tsx
+++ b/src/components/shareBar/ShareBar.styles.tsx
@@ -4,6 +4,16 @@ import { sm } from '../../theme/space'
 import { H6 } from '../typography'
 import { Wrapper } from '../wrapper'
 
+export const ShareBarWrapper = styled(Wrapper)`
+  ${variant({
+    variants: {
+      vertical: {
+        maxWidth: '2em',
+      },
+    },
+  })}
+`
+
 export const Flex = styled(Wrapper).attrs({
   display: 'flex',
   alignItems: 'center',

--- a/src/components/shareBar/ShareBar.styles.tsx
+++ b/src/components/shareBar/ShareBar.styles.tsx
@@ -20,21 +20,6 @@ export const Flex = styled(Wrapper).attrs({
       },
     },
   })}
-
-  > * {
-    ${variant({
-      variants: {
-        horizontal: {
-          marginX: sm / 4,
-          marginY: 0,
-        },
-        vertical: {
-          marginX: 0,
-          marginY: sm / 4,
-        },
-      },
-    })}
-  }
 `
 
 export const ShareText = styled(H6).attrs({ mb: 0 })`
@@ -42,8 +27,24 @@ export const ShareText = styled(H6).attrs({ mb: 0 })`
     variants: {
       vertical: {
         transform: 'rotate(90deg)',
-        marginY: -10,
-        marginX: -50,
+      },
+    },
+  })}
+`
+
+export const SocialsWrapper = styled(Wrapper).attrs({
+  display: 'flex',
+})`
+  ${variant({
+    variants: {
+      horizontal: {
+        flexDirection: 'row',
+        marginLeft: 'sm',
+      },
+      vertical: {
+        flexDirection: 'column',
+        transform: 'translateY(22px)',
+        marginTop: 'sm',
       },
     },
   })}
@@ -51,5 +52,15 @@ export const ShareText = styled(H6).attrs({ mb: 0 })`
 
 export const StyledLink = styled.a`
   text-decoration: none;
-  width: 1em;
+
+  ${variant({
+    variants: {
+      horizontal: {
+        marginX: sm / 4,
+      },
+      vertical: {
+        marginY: sm / 4,
+      },
+    },
+  })}
 `

--- a/src/components/shareBar/ShareBar.styles.tsx
+++ b/src/components/shareBar/ShareBar.styles.tsx
@@ -4,11 +4,15 @@ import { sm } from '../../theme/space'
 import { H6 } from '../typography'
 import { Wrapper } from '../wrapper'
 
-export const ShareBarWrapper = styled(Wrapper)`
+export const ShareBarWrapper = styled(Wrapper).attrs({
+  display: 'inline-block',
+})`
   ${variant({
     variants: {
       vertical: {
         maxWidth: '2em',
+        paddingTop: '32px',
+        paddingBottom: '22px',
       },
     },
   })}

--- a/src/components/shareBar/ShareBar.tsx
+++ b/src/components/shareBar/ShareBar.tsx
@@ -20,7 +20,7 @@ const SOCIALS: { name: SharePlatform }[] = [
 ]
 
 export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
-  <ShareBarWrapper display="inline-block" {...{ variant }} {...props}>
+  <ShareBarWrapper {...{ variant }} {...props}>
     <Flex {...{ variant }}>
       <ShareText {...{ variant }}>Share</ShareText>
       <SocialsWrapper {...{ variant }}>

--- a/src/components/shareBar/ShareBar.tsx
+++ b/src/components/shareBar/ShareBar.tsx
@@ -14,20 +14,18 @@ const SOCIALS: { name: SharePlatform }[] = [
 ]
 
 export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
-  <div {...props}>
-    <Flex {...{ variant }}>
-      <ShareText {...{ variant }}>Share</ShareText>
-      {SOCIALS.map(({ name }) => (
-        <StyledLink
-          key={name}
-          href={generateShareUrl(name, content)}
-          title={`Share via ${generatePlatformName(name)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Icon name={name} variant="indigo" />
-        </StyledLink>
-      ))}
-    </Flex>
-  </div>
+  <Flex {...{ variant }} {...props}>
+    <ShareText {...{ variant }}>Share</ShareText>
+    {SOCIALS.map(({ name }) => (
+      <StyledLink
+        key={name}
+        href={generateShareUrl(name, content)}
+        title={`Share via ${generatePlatformName(name)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Icon name={name} variant="indigo" />
+      </StyledLink>
+    ))}
+  </Flex>
 )

--- a/src/components/shareBar/ShareBar.tsx
+++ b/src/components/shareBar/ShareBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Icon } from '../icon'
 import { generateShareUrl, SharePlatform } from '../../utils/share-utils'
 import { Wrapper } from '../wrapper'
-import { Flex, ShareText, StyledLink } from './ShareBar.styles'
+import { Flex, ShareText, SocialsWrapper, StyledLink } from './ShareBar.styles'
 import { ShareBarProps } from './ShareBar.types'
 import { generatePlatformName } from './ShareBar.utils'
 
@@ -18,17 +18,20 @@ export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
   <Wrapper display="inline-block" {...props}>
     <Flex {...{ variant }}>
       <ShareText {...{ variant }}>Share</ShareText>
-      {SOCIALS.map(({ name }) => (
-        <StyledLink
-          key={name}
-          href={generateShareUrl(name, content)}
-          title={`Share via ${generatePlatformName(name)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Icon name={name} variant="indigo" />
-        </StyledLink>
-      ))}
+      <SocialsWrapper {...{ variant }}>
+        {SOCIALS.map(({ name }) => (
+          <StyledLink
+            key={name}
+            href={generateShareUrl(name, content)}
+            title={`Share via ${generatePlatformName(name)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            {...{ variant }}
+          >
+            <Icon name={name} variant="indigo" />
+          </StyledLink>
+        ))}
+      </SocialsWrapper>
     </Flex>
   </Wrapper>
 )

--- a/src/components/shareBar/ShareBar.tsx
+++ b/src/components/shareBar/ShareBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Icon } from '../icon'
 import { generateShareUrl, SharePlatform } from '../../utils/share-utils'
+import { Wrapper } from '../wrapper'
 import { Flex, ShareText, StyledLink } from './ShareBar.styles'
 import { ShareBarProps } from './ShareBar.types'
 import { generatePlatformName } from './ShareBar.utils'
@@ -14,18 +15,20 @@ const SOCIALS: { name: SharePlatform }[] = [
 ]
 
 export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
-  <Flex {...{ variant }} {...props}>
-    <ShareText {...{ variant }}>Share</ShareText>
-    {SOCIALS.map(({ name }) => (
-      <StyledLink
-        key={name}
-        href={generateShareUrl(name, content)}
-        title={`Share via ${generatePlatformName(name)}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Icon name={name} variant="indigo" />
-      </StyledLink>
-    ))}
-  </Flex>
+  <Wrapper display="inline-block" {...props}>
+    <Flex {...{ variant }}>
+      <ShareText {...{ variant }}>Share</ShareText>
+      {SOCIALS.map(({ name }) => (
+        <StyledLink
+          key={name}
+          href={generateShareUrl(name, content)}
+          title={`Share via ${generatePlatformName(name)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Icon name={name} variant="indigo" />
+        </StyledLink>
+      ))}
+    </Flex>
+  </Wrapper>
 )

--- a/src/components/shareBar/ShareBar.tsx
+++ b/src/components/shareBar/ShareBar.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { Icon } from '../icon'
 import { generateShareUrl, SharePlatform } from '../../utils/share-utils'
-import { Wrapper } from '../wrapper'
-import { Flex, ShareText, SocialsWrapper, StyledLink } from './ShareBar.styles'
+import {
+  ShareBarWrapper,
+  Flex,
+  ShareText,
+  SocialsWrapper,
+  StyledLink,
+} from './ShareBar.styles'
 import { ShareBarProps } from './ShareBar.types'
 import { generatePlatformName } from './ShareBar.utils'
 
@@ -15,7 +20,7 @@ const SOCIALS: { name: SharePlatform }[] = [
 ]
 
 export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
-  <Wrapper display="inline-block" {...props}>
+  <ShareBarWrapper display="inline-block" {...{ variant }} {...props}>
     <Flex {...{ variant }}>
       <ShareText {...{ variant }}>Share</ShareText>
       <SocialsWrapper {...{ variant }}>
@@ -33,5 +38,5 @@ export const ShareBar = ({ variant, content, ...props }: ShareBarProps) => (
         ))}
       </SocialsWrapper>
     </Flex>
-  </Wrapper>
+  </ShareBarWrapper>
 )

--- a/src/components/shareBar/ShareBar.types.ts
+++ b/src/components/shareBar/ShareBar.types.ts
@@ -1,6 +1,11 @@
+import { ResponsiveValue } from 'styled-system'
 import { ShareContent } from '../../utils/share-utils'
 
+export const VARIANTS = ['horizontal', 'vertical'] as const
+
+type ShareBarVariant = typeof VARIANTS[number]
+
 export interface ShareBarProps {
-  variant: 'horizontal' | 'vertical'
+  variant: ResponsiveValue<ShareBarVariant>
   content: ShareContent
 }

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -1,0 +1,118 @@
+import { v4 as uuid } from 'uuid'
+import { Document } from '@contentful/rich-text-types'
+import { getFirstParagraph } from './document-utils'
+
+describe('getFirstParagraph', () => {
+  it('should get first paragraph when first node is a paragraph', () => {
+    const paragraph = uuid()
+    const json: Document = {
+      content: [
+        {
+          // @ts-ignore
+          nodeType: 'paragraph',
+          content: [
+            {
+              // @ts-ignore
+              nodeType: 'text',
+              value: paragraph,
+              data: {},
+              marks: [],
+            },
+          ],
+        },
+      ],
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual(paragraph)
+  })
+
+  it('should get first paragraph when first node is not a paragraph', () => {
+    const paragraph = uuid()
+    const json: Document = {
+      content: [
+        {
+          // @ts-ignore
+          nodeType: uuid(),
+          content: [],
+        },
+        {
+          // @ts-ignore
+          nodeType: 'paragraph',
+          content: [
+            {
+              // @ts-ignore
+              nodeType: 'text',
+              value: paragraph,
+              data: {},
+              marks: [],
+            },
+          ],
+        },
+      ],
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual(paragraph)
+  })
+
+  it('should return empty string if no content exists in document', () => {
+    const json: Document = {
+      // @ts-ignore
+      nodeType: uuid(),
+      content: [],
+      data: {},
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual('')
+  })
+
+  it('should return empty string if no paragraphs exist in document', () => {
+    const json: Document = {
+      content: [
+        {
+          // @ts-ignore
+          nodeType: uuid(),
+          content: [],
+        },
+      ],
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual('')
+  })
+
+  it('should return empty string if first paragraph contains no content', () => {
+    const json: Document = {
+      content: [
+        {
+          // @ts-ignore
+          nodeType: 'paragraph',
+          content: [],
+        },
+      ],
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual('')
+  })
+
+  it('should return empty string if first paragraph content has no value', () => {
+    const json: Document = {
+      content: [
+        {
+          // @ts-ignore
+          nodeType: 'paragraph',
+          content: [
+            {
+              // @ts-ignore
+              nodeType: 'text',
+              // @ts-ignore
+              value: null,
+              data: {},
+              marks: [],
+            },
+          ],
+        },
+      ],
+    }
+    const actual = getFirstParagraph(json)
+    expect(actual).toEqual('')
+  })
+})

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -1,0 +1,9 @@
+import { Document, Text } from '@contentful/rich-text-types'
+
+export const getFirstParagraph = (json: Document): string => {
+  const [firstParagraph] = json.content.filter(
+    node => node.nodeType === 'paragraph'
+  )
+  const block = firstParagraph?.content[0] as Text
+  return block?.value || ''
+}


### PR DESCRIPTION
This also includes a small refactor of the `ShareBar` component (and places where it's used) as it was not rendering correctly.

The `ShareBar` reflector includes:

- moving the `variant` prop to a responsive value
- ensuring the correct height/width of the component was respected when margins were applied
- sorted out the DOM hierarchy within the component
- leverage the use of `styled-system` and our theming
- fixed the `vertical` `variant` of the component which wouldn't allow the user to select the `email` option

In addition, on the YMUW campaign page, the share bar was bleeding into the title on window resize.