### PR TITLE
WEBNEW-233 💄 Blog category colours

### DIFF
--- a/src/blog/article/BlogArticlePage.tsx
+++ b/src/blog/article/BlogArticlePage.tsx
@@ -13,10 +13,18 @@ import { colors } from '../../theme/colors'
 import { MAX_CONTENT_WIDTH, Content } from './BlogArticlePage.styles'
 import { BlogArticlePageProps } from './BlogArticlePage.types'
 
-const getCategoryColor = (category: string) => {
+const getCategoryColor = (category: string): string => {
   switch (category) {
+    case 'Arts & culture':
+      return colors.tomato
+    case 'History':
+      return colors.lemonGreen
+    case 'Life':
+      return colors.skyBlue
+    case 'Stories':
+      return colors.fuscia
     default:
-      return colors.mexicanPink
+      return ''
   }
 }
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -5,7 +5,7 @@ export const colors = {
   lightGrey: '#EFEFEF',
   white: '#FFFFFF',
   yellow: '#FFD95E',
-  tomato: '#FF5B44',
+  tomato: '#FF7A67',
   pink: '#ED2C6E',
   fuscia: '#FF88F1',
   electricPurple: '#BC01FF',


### PR DESCRIPTION
Updated blog category colours to match design request. Tags render as below:

![Screenshot 2021-02-03 at 19 50 57](https://user-images.githubusercontent.com/6469639/106801806-162bef80-665a-11eb-9db9-05c1686417cf.png)
![Screenshot 2021-02-03 at 19 50 46](https://user-images.githubusercontent.com/6469639/106801803-15935900-665a-11eb-99c7-7665ce91f044.png)
![Screenshot 2021-02-03 at 19 52 54](https://user-images.githubusercontent.com/6469639/106801807-162bef80-665a-11eb-847b-19b420703111.png)
![Screenshot 2021-02-03 at 19 54 00](https://user-images.githubusercontent.com/6469639/106801809-16c48600-665a-11eb-8657-e8528ef9280b.png)
